### PR TITLE
Explicitly check for "mal" binary name when ignoring self

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -477,7 +477,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 		// TODO: If we match multiple rules within a single namespace, merge matchstrings
 	}
 
-	if all(ignoreSelf, fr.IsMalcontent, ignoreMalcontent, filepath.Base(path) == NAME) {
+	if all(ignoreSelf, fr.IsMalcontent, ignoreMalcontent, filepath.Base(path) == "mal") {
 		return malcontent.FileReport{}, nil
 	}
 


### PR DESCRIPTION
As part of #464, I used the full `malcontent` string when checking whether the Rule name and metadata were for `malcontent` rather than just `mal` in the event we had other partial `mal` string matches in the future.

Since the `malcontent` binary is `mal`, the `filepath.Base(path) == NAME` check was failing because `mal` != `malcontent`.

This PR explicitly checks whether `filepath.Base(path)` is `mal`. I tested this locally and the ignore behavior worked as expected.

I'll cut `1.0.1` to get this out before merging https://github.com/wolfi-dev/os/pull/29171.