### PR TITLE
Check if frs sync.Map is nil within handleArchive

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -243,17 +243,19 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 				}
 			}
 
-			frs.Range(func(key, value any) bool {
-				if key == nil || value == nil {
-					return true
-				}
-				if k, ok := key.(string); ok {
-					if fr, ok := value.(*malcontent.FileReport); ok {
-						scanPathFindings.Store(k, fr)
+			if frs != nil {
+				frs.Range(func(key, value any) bool {
+					if key == nil || value == nil {
+						return true
 					}
-				}
-				return true
-			})
+					if k, ok := key.(string); ok {
+						if fr, ok := value.(*malcontent.FileReport); ok {
+							scanPathFindings.Store(k, fr)
+						}
+					}
+					return true
+				})
+			}
 			return nil
 		}
 


### PR DESCRIPTION
@hectorj2f pointed out that we were still seeing nil pointer dereferences/panics when failing to scan archives (i.e., `frs` is `nil`):
```go
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x48955a]

goroutine 1652 [running]:
sync.(*Map).loadReadOnly(...)
	sync/map.go:114
sync.(*Map).Range(0x0?, 0x9a9154?)
	sync/map.go:478 +0x1a
github.com/chainguard-dev/malcontent/pkg/action.recursiveScan.func1({0xc00171fef0, 0x8d})
	github.com/chainguard-dev/malcontent/pkg/action/scan.go:246 +0x305
github.com/chainguard-dev/malcontent/pkg/action.recursiveScan.func3()
	github.com/chainguard-dev/malcontent/pkg/action/scan.go:292 +0x70
golang.org/x/sync/errgroup.(*Group).Go.func1()
	golang.org/x/sync@v0.8.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
	golang.org/x/sync@v0.8.0/errgroup/errgroup.go:75 +0x96
```

This is the same issue as #462 but I only fixed the bug in the `errIfHitOrMiss`.