### PR TITLE
Small archive extraction fixes; support bzip2 archives

### DIFF
--- a/pkg/action/programkind.go
+++ b/pkg/action/programkind.go
@@ -20,6 +20,8 @@ import (
 
 var archiveMap = map[string]bool{
 	".apk":    true,
+	".bz2":    true,
+	".bzip2":  true,
 	".gem":    true,
 	".gz":     true,
 	".jar":    true,


### PR DESCRIPTION
We noticed a few issues around extracting archives and I also noticed that we never added bzip2 support.

This PR:
- fixes a bug where we wouldn't seek to the file origin for `.apk`, `.gz`, and `.tar.gz` files (that statement never ran `tf.Seek(0, io.SeekStart)`) by moving the seek code out of the switch statements
- fixes a bug where we didn't check for `io.ErrUnexpectedEOF` when iterating through the `tar` reader
- adds `bzip2` archive support