### PR TITLE
Allow for multiple scan path inputs for `analyze` and `scan`

### DIFF
--- a/malcontent.go
+++ b/malcontent.go
@@ -373,7 +373,7 @@ func main() {
 						mc.OCI = true
 					case c.String("image") == "" && !c.Bool("processes"):
 						cmdArgs := c.Args().Slice()
-						mc.ScanPaths = []string{cmdArgs[0]}
+						mc.ScanPaths = cmdArgs
 					case c.Bool("processes"):
 						mc.Processes = true
 					}
@@ -454,7 +454,7 @@ func main() {
 						mc.OCI = true
 					case c.String("image") == "" && !c.Bool("processes"):
 						cmdArgs := c.Args().Slice()
-						mc.ScanPaths = []string{cmdArgs[0]}
+						mc.ScanPaths = cmdArgs
 					case c.Bool("processes"):
 						mc.Processes = true
 					}


### PR DESCRIPTION
Closes #478 

Only considering `[]string{cmdArgs[0]}` would cut off any additional paths provided to `analyze` or `scan`.

This PR adds support for multiple paths.

e.g.,
```
$ go run . scan ~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/2261.ac6a26854d5acee00776.js /Users/evangibler/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/5398.d0c11aa7c1232f4afe44.js
[HIGH] ~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/2261.ac6a26854d5acee00776.js:
- obfuscation/js/high_entropy (high entropy javascript (>5.37))
- obfuscation/js/parseInt (javascript obfuscation (integer parsing))

[HIGH] ~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/5398.d0c11aa7c1232f4afe44.js:
- obfuscation/js/high_entropy (high entropy javascript (>5.37))
```

```
$ go run . analyze ~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/2261.ac6a26854d5acee00776.js /Users/evangibler/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/5398.d0c11aa7c1232f4afe44.js
~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/2261.ac6a26854d5acee00776.js [🔥 HIGH]
------------------------------------------------------------------------------------------------------------------------------------------------
RISK  KEY                          DESCRIPTION                               EVIDENCE
------------------------------------------------------------------------------------------------------------------------------------------------
LOW   encoding/json/decode         Decodes JSON messages                     JSON.parse
LOW   encoding/json/encode         encodes JSON                              JSON.stringify
LOW   net/url                      Handles URL strings                       new URL
LOW   ref/site/url                 contains embedded HTTPS URLs              https://grafana.com/docs/grafana/latest/datasources/elasticsearch
LOW   ref/words/plugin             references a 'plugin'                     plugin
MED   net/http/cookies             access HTTP resources using cookies       Cookie
                                                                             HTTP
MED   net/http/post                submits content to websites               Content-Type
                                                                             HTTP
                                                                             POST
                                                                             http
HIGH  obfuscation/js/high_entropy  high entropy javascript (>5.37)
HIGH  obfuscation/js/parseInt      javascript obfuscation (integer parsing)  const
                                                                             function(
                                                                             parseInt
                                                                             {return
------------------------------------------------------------------------------------------------------------------------------------------------

~/Downloads/grafana/packages/x86_64/usr/share/grafana/public/build/5398.d0c11aa7c1232f4afe44.js [🔥 HIGH]
----------------------------------------------------------------------------------------------------------------------------
RISK  KEY                           DESCRIPTION                                         EVIDENCE
----------------------------------------------------------------------------------------------------------------------------
LOW   net/url                       Handles URL strings                                 new URL
LOW   ref/site/url                  contains embedded HTTPS URLs                        https://lodash.com/license
                                                                                        https://npms.io/search?q=ponyfill.
                                                                                        https://openjsf.org/
MED   obfuscation/js/function_spam  javascript obfuscation (excessive const functions)  const
                                                                                        function(
                                                                                        {return
MED   techniques/code_eval          evaluate code dynamically using exec()              exec(i))
                                                                                        exec(n))
                                                                                        exec(qe
                                                                                        exec(v)
HIGH  obfuscation/js/high_entropy   high entropy javascript (>5.37)
------------------------------------------------------------------------------------------------------------------------
```