### PR TITLE
Allow for rule severity overrides; add default ignore tags

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -170,6 +170,18 @@ func main() {
 				minRisk = -1
 			}
 
+			// Add the default tags to ignore regardless of whether they're passed in or not
+			defaultIgnore := []string{
+				"false_positive",
+				"ignore",
+			}
+
+			for _, t := range defaultIgnore {
+				if !slices.Contains(ignoreTags, t) {
+					ignoreTags = append(ignoreTags, t)
+				}
+			}
+
 			if outputFlag != "" {
 				outFile, err = os.OpenFile(outputFlag, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 				if err != nil {
@@ -266,7 +278,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:        "ignore-tags",
-				Value:       "",
+				Value:       "false_positive,ignore",
 				Usage:       "Rule tags to ignore",
 				Destination: &ignoreTagsFlag,
 			},

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -58,6 +58,9 @@ type Behavior struct {
 
 	// ID is the original map key from map[string]*Behavior
 	ID string `json:",omitempty" yaml:",omitempty"`
+
+	// Name is the value of m.Rule
+	RuleName string `json:",omitempty" yaml:",omitempty"`
 }
 
 type FileReport struct {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -295,7 +295,7 @@ func mungeDescription(s string) string {
 	return s
 }
 
-//nolint:cyclop,gocognit // ignore complexity of 44, 103
+//nolint:cyclop // ignore complexity of 44
 func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malcontent.Config, expath string) (malcontent.FileReport, error) {
 	ignoreTags := c.IgnoreTags
 	minScore := c.MinRisk
@@ -461,7 +461,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 					if ob.RuleName == overrideRule {
 						b = ob
 						b.RuleName = m.Rule
-						b.Description = fmt.Sprintf("%s, overridden by %s", b.Description, m.Rule)
+						b.Description = fmt.Sprintf("%s, [%s]", b.Description, m.Rule)
 						b.RiskScore = overrideSev
 						b.RiskLevel = RiskLevels[overrideSev]
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -72,7 +72,7 @@ var thirdPartyCriticalSources = map[string]bool{
 	"JPCERT":    true,
 }
 
-// authorWithURLRe matcehs "Arnim Rupp (https://github.com/ruppde)"
+// authorWithURLRe matches "Arnim Rupp (https://github.com/ruppde)"
 var authorWithURLRe = regexp.MustCompile(`(.*?) \((http.*)\)`)
 
 var threatHuntingKeywordRe = regexp.MustCompile(`Detection patterns for the tool '(.*)' taken from the ThreatHunting-Keywords github project`)
@@ -295,7 +295,7 @@ func mungeDescription(s string) string {
 	return s
 }
 
-//nolint:cyclop,gocognit // ignore complexity of 44, 101
+//nolint:cyclop // ignore complexity of 44
 func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malcontent.Config, expath string) (malcontent.FileReport, error) {
 	ignoreTags := c.IgnoreTags
 	minScore := c.MinRisk

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -459,11 +459,9 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 				// Store its behavior in the current behavior and remove the original behavior
 				for i, ob := range fr.Behaviors {
 					if ob.RuleName == overrideRule {
-						if b.Description != "" {
-							b.Description = fmt.Sprintf("%s, %s", b.Description, ob.Description)
-						} else {
-							b.Description = ob.Description
-						}
+						b = ob
+						b.RuleName = m.Rule
+						b.Description = fmt.Sprintf("%s, overridden by %s", b.Description, m.Rule)
 						b.RiskScore = overrideSev
 						b.RiskLevel = RiskLevels[overrideSev]
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -295,7 +295,7 @@ func mungeDescription(s string) string {
 	return s
 }
 
-//nolint:cyclop // ignore complexity of 44
+//nolint:cyclop,gocognit // ignore complexity of 44, 103
 func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malcontent.Config, expath string) (malcontent.FileReport, error) {
 	ignoreTags := c.IgnoreTags
 	minScore := c.MinRisk


### PR DESCRIPTION
#473 got a little messy after I refactored everything (+ merge conflicts).

This PR implements the suggestions in #471; namely, the ability to override a rule's severity via metadata.

To do this, we generate a map of rule matches, check if a metadata key exists in that map, and then iterate through the file's behaviors to update the matching rule's severity with the value of the metadata field.

We've also wanted to ignore rules based on tags, so I added default ignores for `false_positive` or `ignore` tags (and add them to the `ignoreTags` slice if they're omitted via the CLI).