### PR TITLE
Add new renderer to display string matches for rules

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -267,7 +267,7 @@ func main() {
 			&cli.StringFlag{
 				Name:        "format",
 				Value:       "auto",
-				Usage:       "Output format (json, markdown, simple, terminal, yaml)",
+				Usage:       "Output format (json, markdown, simple, strings, terminal, yaml)",
 				Destination: &formatFlag,
 			},
 			&cli.BoolFlag{

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -25,6 +25,8 @@ func New(kind string, w io.Writer) (malcontent.Renderer, error) {
 		return NewJSON(w), nil
 	case "simple":
 		return NewSimple(w), nil
+	case "strings":
+		return NewStringMatches(w), nil
 	default:
 		return nil, fmt.Errorf("unknown renderer: %q", kind)
 	}

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -1,0 +1,99 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// String matches renderer
+//
+// Example:
+//
+// Displaying matches for /sbin/ping [MED]
+// ---------------------------------------
+// _connect [MED]:
+// - _connect
+// bsd_if [LOW]:
+// - if_nametoindex
+// bsd_ifaddrs [MED]:
+// - freeifaddrs
+// - getifaddrs
+// generic_scan_tool [MED]:
+// - connect
+// - gethostbyname
+// - port
+// - scan
+// - socket
+// gethostbyaddr [LOW]:
+// - gethostbyaddr
+// ...
+
+package render
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+	"github.com/fatih/color"
+)
+
+// Map to handle RiskScore -> RiskLevel conversions.
+var riskLevels = map[int]string{
+	0: "NONE",     // harmless: common to all executables, no system impact
+	1: "LOW",      // undefined: low impact, common to good and bad executables
+	2: "MEDIUM",   // notable: may have impact, but common
+	3: "HIGH",     // suspicious: uncommon, but could be legit
+	4: "CRITICAL", // critical: certainly malware
+}
+
+type StringMatches struct {
+	w io.Writer
+}
+
+func NewStringMatches(w io.Writer) StringMatches {
+	return StringMatches{w: w}
+}
+
+type Match struct {
+	Description string
+	Matches     []string
+	Risk        int
+	Rule        string
+}
+
+func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error {
+	if len(fr.Behaviors) == 0 {
+		return nil
+	}
+
+	matches := []Match{}
+	sort.Slice(fr.Behaviors, func(i, j int) bool {
+		return fr.Behaviors[i].RuleName < fr.Behaviors[j].RuleName
+	})
+	for _, b := range fr.Behaviors {
+		if b.MatchStrings != nil {
+			matches = append(matches, Match{
+				Matches: b.MatchStrings,
+				Risk:    b.RiskScore,
+				Rule:    b.RuleName,
+			})
+		}
+	}
+
+	prefix := "Displaying matches for"
+	fmt.Fprintf(r.w, "%s %s %s%s%s\n", prefix, color.HiGreenString(fr.Path), color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"))
+	fmt.Fprintf(r.w, "%s\n", strings.Repeat("-", len(prefix+fr.Path+fr.RiskLevel)+1))
+	for _, m := range matches {
+		fmt.Fprintf(r.w, "%s %s%s%s: \n%s%s\n", color.HiGreenString(m.Rule), color.HiBlackString("["), briefRiskColor(riskLevels[m.Risk]), color.HiBlackString("]"), color.HiBlackString("- "), strings.Join(m.Matches, color.HiBlackString("\n- ")))
+	}
+	return nil
+}
+
+func (r StringMatches) Full(_ context.Context, rep *malcontent.Report) error {
+	// Non-diff files are handled on the fly by File()
+	if rep.Diff == nil {
+		return nil
+	}
+
+	return fmt.Errorf("diffs are unsupported by the StringMatches renderer")
+}

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -56,9 +56,9 @@ func NewStringMatches(w io.Writer) StringMatches {
 
 type Match struct {
 	Description string
-	Matches     []string
 	Risk        int
 	Rule        string
+	Strings     []string
 }
 
 func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error {
@@ -71,21 +71,23 @@ func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error 
 		return fr.Behaviors[i].RuleName < fr.Behaviors[j].RuleName
 	})
 	for _, b := range fr.Behaviors {
-		if b.MatchStrings != nil {
+		if len(b.MatchStrings) > 0 {
 			matches = append(matches, Match{
-				Matches: b.MatchStrings,
 				Risk:    b.RiskScore,
 				Rule:    b.RuleName,
+				Strings: b.MatchStrings,
 			})
 		}
 	}
 
-	prefix := "String matches for"
-	header := fmt.Sprintf("%s %s %s%s%s:\n", prefix, color.HiGreenString(fr.Path), color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"))
-	fmt.Fprintf(r.w, header)
+	prefix := "Matches for"
+	rUnit := plural("rule", len(matches))
+	fmt.Fprintf(r.w, "%s %s %s%s%s %s%s %s%s:\n", prefix, color.HiGreenString(fr.Path), color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"), color.HiBlackString("("), color.HiGreenString(fmt.Sprintf("%d", len(matches))), color.HiGreenString(rUnit), color.HiBlackString(")"))
 	for _, m := range matches {
-		fmt.Fprintf(r.w, "%s %s%s%s: \n%s%s\n", color.HiGreenString(m.Rule), color.HiBlackString("["), briefRiskColor(riskLevels[m.Risk]), color.HiBlackString("]"), color.HiBlackString("- "), strings.Join(m.Matches, color.HiBlackString("\n- ")))
+		sUnit := plural("string", len(m.Strings))
+		fmt.Fprintf(r.w, "%s %s%s%s %s%s %s%s: \n%s%s\n", color.HiCyanString(m.Rule), color.HiBlackString("["), briefRiskColor(riskLevels[m.Risk]), color.HiBlackString("]"), color.HiBlackString("("), color.HiGreenString(fmt.Sprintf("%d", len(m.Strings))), color.HiGreenString(sUnit), color.HiBlackString(")"), color.HiBlackString("- "), strings.Join(m.Strings, color.HiBlackString("\n- ")))
 	}
+
 	return nil
 }
 
@@ -96,4 +98,12 @@ func (r StringMatches) Full(_ context.Context, rep *malcontent.Report) error {
 	}
 
 	return fmt.Errorf("diffs are unsupported by the StringMatches renderer")
+}
+
+// plural returns a pluralized string if the length of l is greater than 1.
+func plural(s string, l int) string {
+	if l > 1 {
+		return fmt.Sprintf("%ss", s)
+	}
+	return s
 }

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -80,9 +80,9 @@ func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error 
 		}
 	}
 
-	prefix := "Displaying matches for"
-	fmt.Fprintf(r.w, "%s %s %s%s%s\n", prefix, color.HiGreenString(fr.Path), color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"))
-	fmt.Fprintf(r.w, "%s\n", strings.Repeat("-", len(prefix+fr.Path+fr.RiskLevel)+1))
+	prefix := "String matches for"
+	header := fmt.Sprintf("%s %s %s%s%s:\n", prefix, color.HiGreenString(fr.Path), color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"))
+	fmt.Fprintf(r.w, header)
 	for _, m := range matches {
 		fmt.Fprintf(r.w, "%s %s%s%s: \n%s%s\n", color.HiGreenString(m.Rule), color.HiBlackString("["), briefRiskColor(riskLevels[m.Risk]), color.HiBlackString("]"), color.HiBlackString("- "), strings.Join(m.Matches, color.HiBlackString("\n- ")))
 	}

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -5,23 +5,20 @@
 //
 // Example:
 //
-// Displaying matches for /sbin/ping [MED]
-// ---------------------------------------
-// _connect [MED]:
+// Matches for /sbin/ping [MED] (15 rules):
+// _connect [MED] (1 string):
 // - _connect
-// bsd_if [LOW]:
+// bsd_if [LOW] (1 string):
 // - if_nametoindex
-// bsd_ifaddrs [MED]:
+// bsd_ifaddrs [MED] (2 strings):
 // - freeifaddrs
 // - getifaddrs
-// generic_scan_tool [MED]:
+// generic_scan_tool [MED] (5 strings):
 // - connect
 // - gethostbyname
 // - port
 // - scan
 // - socket
-// gethostbyaddr [LOW]:
-// - gethostbyaddr
 // ...
 
 package render

--- a/pkg/render/terminal_brief.go
+++ b/pkg/render/terminal_brief.go
@@ -32,9 +32,9 @@ func NewTerminalBrief(w io.Writer) TerminalBrief {
 func briefRiskColor(level string) string {
 	switch level {
 	case "LOW":
-		return color.HiGreenString("LOW ")
+		return color.HiGreenString("LOW")
 	case "MEDIUM", "MED":
-		return color.HiYellowString("MED ")
+		return color.HiYellowString("MED")
 	case "HIGH":
 		return color.HiRedString("HIGH")
 	case "CRITICAL", "CRIT":


### PR DESCRIPTION
I've been running `yara -r <rule path> <path> -s` a lot recently. Now that we track rule names in the `Behavior` struct, we can correlate this to the rule matches.

This PR adds a new renderer to display the file report path, its risk level, the number of rules that matched, each rule that has string matches, and the number of strings per rule match (sorted alphabetically by rule name ascending).

For example:
```
go run cmd/mal/mal.go --format strings analyze /usr/bin/bash
Matches for /usr/bin/bash [HIGH] (35 rules):
HOME [LOW] (2 strings): 
- HOME
- getenv
LANG_getenv [LOW] (2 strings): 
- LANG
- getenv
SHELL [LOW] (1 string): 
- SHELL
TERM [LOW] (1 string): 
- TERM
TMPDIR [LOW] (2 strings): 
- TMPDIR
- getenv
bash_history [HIGH] (1 string): 
- .bash_history
calls_shell [MED] (1 string): 
- /bin/sh
chdir_shell [LOW] (1 string): 
- cd which change the
chmod [MED] (1 string): 
- chmod
custom_path [LOW] (4 strings): 
- /bin:/usr/
- /sbin:/bin
- /usr/bin:/sbin
- PATH
dlsym [MED] (1 string): 
- dlsym
etc_hosts [MED] (1 string): 
- /etc/hosts
etc_path [LOW] (4 strings): 
- /etc/bash.bashrc
- /etc/hosts
- /etc/inputrc
- /etc/profile
```

Here's what it looks like in-terminal for `analyze` (partial screenshot):
![image](https://github.com/user-attachments/assets/4580dd68-79d3-4449-9f84-1083f5339314)

The renderer works for `scan` as well:
![image](https://github.com/user-attachments/assets/e4488222-0914-4c9c-9087-0542da671b45)