### PR TITLE
Turn on prealloc linting rule, implement suggestions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,6 +131,7 @@ linters:
     - nilerr
     - noctx
     - nolintlint
+    - prealloc
     - predeclared
     # disabling for the initial iteration of the linting tool
     # - promlinter

--- a/pkg/action/archive_test.go
+++ b/pkg/action/archive_test.go
@@ -118,7 +118,7 @@ func TestExtractTar(t *testing.T) {
 	if len(dirFiles) != len(want) {
 		t.Fatalf("unexpected number of files in dir: %d", len(dirFiles))
 	}
-	var got []string
+	got := make([]string, 0, len(dirFiles))
 	for _, f := range dirFiles {
 		got = append(got, f.Name())
 	}
@@ -146,7 +146,7 @@ func TestExtractGzip(t *testing.T) {
 	if len(dirFiles) != len(want) {
 		t.Fatalf("unexpected number of files in dir: %d", len(dirFiles))
 	}
-	var got []string
+	got := make([]string, 0, len(dirFiles))
 	for _, f := range dirFiles {
 		got = append(got, f.Name())
 	}
@@ -174,7 +174,7 @@ func TestExtractZip(t *testing.T) {
 	if len(dirFiles) != len(want) {
 		t.Fatalf("unexpected number of files in dir: %d", len(dirFiles))
 	}
-	var got []string
+	got := make([]string, 0, len(dirFiles))
 	for _, f := range dirFiles {
 		got = append(got, f.Name())
 	}
@@ -202,7 +202,7 @@ func TestExtractNestedArchive(t *testing.T) {
 	if len(dirFiles) != len(want) {
 		t.Fatalf("unexpected number of files in dir: %d", len(dirFiles))
 	}
-	var got []string
+	got := make([]string, 0, len(dirFiles))
 	for _, f := range dirFiles {
 		got = append(got, f.Name())
 	}

--- a/pkg/action/process.go
+++ b/pkg/action/process.go
@@ -21,7 +21,7 @@ func GetAllProcessPaths(ctx context.Context) ([]Process, error) {
 	}
 
 	// Store PIDs and their respective commands (paths) in a map of paths and their Process structs
-	processMap := make(map[string]Process)
+	processMap := make(map[string]Process, len(procs))
 	for _, p := range procs {
 		path, err := p.Exe()
 		if err != nil {

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -116,7 +116,7 @@ func markdownTable(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc
 		return
 	}
 
-	var kbs []KeyedBehavior
+	kbs := make([]KeyedBehavior, 0, len(fr.Behaviors))
 	for _, b := range fr.Behaviors {
 		kbs = append(kbs, KeyedBehavior{Key: b.ID, Behavior: b})
 	}
@@ -139,7 +139,10 @@ func markdownTable(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc
 		return kbs[i].Behavior.RiskScore > kbs[j].Behavior.RiskScore
 	})
 
-	var data [][]string
+	data := make([][]string, 0, len(kbs))
+	for _, k := range kbs {
+		data = append(data, make([]string, 0, len(k.Behavior.MatchStrings)))
+	}
 
 	for _, k := range kbs {
 		desc := k.Behavior.Description
@@ -184,7 +187,7 @@ func markdownTable(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc
 			key = fmt.Sprintf("**%s**", key)
 		}
 
-		var matchLinks []string
+		matchLinks := make([]string, 0, len(k.Behavior.MatchStrings))
 		for _, m := range k.Behavior.MatchStrings {
 			matchLinks = append(matchLinks, matchFragmentLink(m))
 		}

--- a/pkg/render/stats.go
+++ b/pkg/render/stats.go
@@ -26,7 +26,7 @@ func riskStatistics(files *orderedmap.OrderedMap[string, *malcontent.FileReport]
 		}
 	}
 
-	var stats []malcontent.IntMetric
+	stats := make([]malcontent.IntMetric, 0, len(riskStats))
 	total := func() int {
 		var t int
 		for _, v := range riskMap {
@@ -67,7 +67,7 @@ func pkgStatistics(files *orderedmap.OrderedMap[string, *malcontent.FileReport])
 			return w
 		}(len(k), width)
 	}
-	var stats []malcontent.StrMetric
+	stats := make([]malcontent.StrMetric, 0, len(pkg))
 	for k, v := range pkg {
 		stats = append(stats, malcontent.StrMetric{Key: k, Value: v, Count: pkgMap[k], Total: numNamespaces})
 	}

--- a/pkg/render/stats.go
+++ b/pkg/render/stats.go
@@ -10,8 +10,8 @@ import (
 )
 
 func riskStatistics(files *orderedmap.OrderedMap[string, *malcontent.FileReport]) ([]malcontent.IntMetric, int, int) {
-	riskMap := make(map[int][]string)
-	riskStats := make(map[int]float64)
+	riskMap := make(map[int][]string, files.Len())
+	riskStats := make(map[int]float64, files.Len())
 
 	// as opposed to skipped files
 	processedFiles := 0
@@ -46,8 +46,8 @@ func riskStatistics(files *orderedmap.OrderedMap[string, *malcontent.FileReport]
 
 func pkgStatistics(files *orderedmap.OrderedMap[string, *malcontent.FileReport]) ([]malcontent.StrMetric, int, int) {
 	numNamespaces := 0
-	pkgMap := make(map[string]int)
-	pkg := make(map[string]float64)
+	pkgMap := make(map[string]int, files.Len())
+	pkg := make(map[string]float64, files.Len())
 	for files := files.Oldest(); files != nil; files = files.Next() {
 		for _, namespace := range files.Value.Behaviors {
 			numNamespaces++

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -176,8 +176,9 @@ func wrapKey(s string, i int) string {
 }
 
 func darkenText(s string) string {
-	var cw []string
-	for _, w := range strings.Split(s, "\n") {
+	split := strings.Split(s, "\n")
+	cw := make([]string, 0, len(split))
+	for _, w := range split {
 		cw = append(cw, color.HiBlackString(w))
 	}
 	return strings.Join(cw, "\n")
@@ -196,7 +197,7 @@ func renderTable(ctx context.Context, fr *malcontent.FileReport, w io.Writer, rc
 		return
 	}
 
-	var kbs []KeyedBehavior
+	kbs := make([]KeyedBehavior, 0, len(fr.Behaviors))
 	for _, b := range fr.Behaviors {
 		kbs = append(kbs, KeyedBehavior{Key: b.ID, Behavior: b})
 	}
@@ -215,7 +216,10 @@ func renderTable(ctx context.Context, fr *malcontent.FileReport, w io.Writer, rc
 		return kbs[i].Behavior.RiskScore < kbs[j].Behavior.RiskScore
 	})
 
-	var data [][]string
+	data := make([][]string, 0, len(kbs))
+	for _, k := range kbs {
+		data = append(data, make([]string, 0, len(k.Behavior.MatchStrings)))
+	}
 
 	tWidth := terminalWidth(ctx)
 	keyWidth := 24

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -254,7 +254,7 @@ func matchToString(ruleName string, m yara.MatchString) string {
 
 // extract match strings.
 func matchStrings(ruleName string, ms []yara.MatchString) []string {
-	var raw []string
+	raw := make([]string, 0, len(ms))
 
 	for _, m := range ms {
 		raw = append(raw, matchToString(ruleName, m))

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -354,7 +354,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 	}
 
 	// Store match rules in a map for future override operations
-	mrsMap := make(map[string]yara.MatchRule)
+	mrsMap := make(map[string]yara.MatchRule, len(mrs))
 	for _, m := range mrs {
 		mrsMap[m.Rule] = m
 	}


### PR DESCRIPTION
I was looking at linting rules to help with further optimizations of malcontent and noticed that we hadn't turned on `prealloc`.

Even for relatively small slices, this can have a positive impact: https://oilbeater.com/en/2024/03/04/golang-slice-performance/

This PR enables the rule and makes the appropriate modifications for both slices and maps (even though `prealloc` does not check the latter).