### PR TITLE
Add jaraco py_dropper_chmod override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fix: $(FIXERS)
 # END: lint-install ../malcontent
 
 SAMPLES_REPO ?= chainguard-dev/malcontent-samples
-SAMPLES_COMMIT ?= f56db86f52ef9b647943d9e3b6652a85ccb68266
+SAMPLES_COMMIT ?= 0ff28cbe99bc4610c58016faeb1a806a6e5cebbb
 OUT_DIR=out/samples-$(SAMPLES_COMMIT).tmp
 out/samples-$(SAMPLES_COMMIT):
 	mkdir -p out

--- a/rules/combo/dropper/python.yara
+++ b/rules/combo/dropper/python.yara
@@ -34,7 +34,7 @@ rule py_dropper : high {
     filesize < 16384 and $open and $write and py_fetcher and py_runner
 }
 
-rule py_dropper_chmod : critical {
+rule py_dropper_chmod : high {
   meta:
   	description = "fetch, stores, chmods, and execute programs"
   strings:
@@ -42,11 +42,8 @@ rule py_dropper_chmod : critical {
 	$val_x = "+x"
 	$val_exec = "755"
 	$val_rwx = "777"
-	$not_magic_trace = "print(f\"Downloading magic_trace to: {magic_trace_cache}\")"
-	$not_magic_trace_chmod = "subprocess.run([\"chmod\", \"+x\", magic_trace_cache])"
-	$not_facebook = "# Copyright (c) Facebook, Inc. and its affiliates."
   condition:
-    filesize < 16384 and py_fetcher and py_runner and $chmod and any of ($val*) and none of ($not*)
+    filesize < 16384 and py_fetcher and py_runner and $chmod and any of ($val*)
 }
 
 private rule pythonSetup {

--- a/rules/false_positives/jaraco.yara
+++ b/rules/false_positives/jaraco.yara
@@ -1,0 +1,11 @@
+rule context_init : override {
+  meta:
+    description = "context/__init__.py"
+    py_dropper_chmod = "medium"
+  strings:
+    $chmod = "os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)"
+    $comment1 = "Add support for removing read-only files on Windows."
+    $comment2 = "# change the file to be readable,writable,executable: 0777"
+  condition:
+    all of them
+}

--- a/rules/false_positives/jaraco.yara
+++ b/rules/false_positives/jaraco.yara
@@ -3,9 +3,7 @@ rule context_init : override {
     description = "context/__init__.py"
     py_dropper_chmod = "medium"
   strings:
-    $chmod = "os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)"
-    $comment1 = "Add support for removing read-only files on Windows."
-    $comment2 = "# change the file to be readable,writable,executable: 0777"
+    $comment = "# change the file to be readable,writable,executable: 0777"
   condition:
     all of them
 }

--- a/rules/false_positives/pytorch.yara
+++ b/rules/false_positives/pytorch.yara
@@ -1,0 +1,11 @@
+rule magic_trace : override {
+  meta:
+    description = "functorch/dim/magic_trace.py"
+    py_dropper_chmod = "medium"
+  strings:
+    $facebook = "# Copyright (c) Facebook, Inc. and its affiliates."
+    $magic_trace = "print(f\"Downloading magic_trace to: {magic_trace_cache}\")"
+    $magic_trace_chmod = "subprocess.run([\"chmod\", \"+x\", magic_trace_cache])"
+	condition:
+    all of them
+}

--- a/test_data/python/clean/jaraco/__init__.py.simple
+++ b/test_data/python/clean/jaraco/__init__.py.simple
@@ -1,0 +1,14 @@
+# python/clean/jaraco/__init__.py
+combo/dropper/python
+exec/program
+fs/directory/create
+fs/directory/list
+fs/directory/remove
+fs/file/delete
+fs/permission/modify
+fs/tempdir/create
+kernel/platform
+net/download
+net/url
+net/url/request
+ref/site/url

--- a/test_data/python/clean/magic_trace/magic_trace.py.simple
+++ b/test_data/python/clean/magic_trace/magic_trace.py.simple
@@ -1,4 +1,5 @@
 # python/clean/magic_trace/magic_trace.py
+combo/dropper/python
 exec/program
 fd/read
 fs/permission/modify


### PR DESCRIPTION
Depends on: https://github.com/chainguard-dev/malcontent-samples/pull/12

This addresses one of the outstanding false positives we've seen.