### PR TITLE
programkind: be quiet if EOF reached

### DIFF
--- a/pkg/programkind/programkind.go
+++ b/pkg/programkind/programkind.go
@@ -115,7 +115,7 @@ func File(path string) (*FileType, error) {
 	defer f.Close()
 
 	_, err = io.ReadFull(f, hdr[:])
-	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("read: %w", err)
 	}
 


### PR DESCRIPTION
If you run malcontent on `pkg/action/testdata/static.tar.xz` with the recent programkind refactor, you'll get hundreds of error messages in the logs:

```
o run ./cmd/mal scan pkg/action/testdata/static.tar.xz 2>&1|head           6.9s  Sun 13 Oct 2024 08:26:33 PM EDT
🔎 Scanning "pkg/action/testdata/static.tar.xz"
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/dev/console: read: EOF" path=/tmp/static.tar.xz685360027/dev/console
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/dev/null: read: EOF" path=/tmp/static.tar.xz685360027/dev/null
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/dev/random: read: EOF" path=/tmp/static.tar.xz685360027/dev/random
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/dev/urandom: read: EOF" path=/tmp/static.tar.xz685360027/dev/urandom
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/dev/zero: read: EOF" path=/tmp/static.tar.xz685360027/dev/zero
time=2024-10-13T20:26:58.375-04:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:97 msg="file type failure: /tmp/static.tar.xz685360027/etc/mtab: read: EOF" path=/tmp/static.tar.xz685360027/etc/mtab
```

This treats EOF the same as unexpected EOF's - it processes the data it can and ignores the error.
