### PR TITLE
Fix --min-risk behavior re: overrides

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -383,7 +383,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 		// If running a scan as opposed to an analyze,
 		// drop any matches that fall below the highest risk
 		switch {
-		case risk < minScore && !ignoreMalcontent:
+		case risk < minScore && !ignoreMalcontent && !override:
 			continue
 		case c.Scan && risk < highestRisk && !ignoreMalcontent && !override:
 			continue


### PR DESCRIPTION
Closes: #522

We weren't applying overrides correctly when specifying minimum risk levels because we were dropping the override rule (of lower severity) before adding it to the `fr.Overrides` slice.

With this change (using a simple `high` -> `medium` override):
```
$ go run cmd/mal/mal.go --min-risk high --quantity-increases-risk=true  analyze ./out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py
🔎 Scanning "./out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py"
out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py [🚨 CRITICAL]
-------------------------------------------------------------------------------------------------------------------------------------------------------------
RISK  KEY                   DESCRIPTION                             EVIDENCE                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------
MED   ref/site/exe          accesses hardcoded executable endpoint  https://cdn.discordapp.com/attachments/1222129364288671834/1224848705887404072/main.exe  
HIGH  combo/dropper/python  fetch, stores, and execute programs     open(                                                                                    
                                                                    write(                                                                                   
HIGH  ref/site/download     References known file hosting site      cdn.discordapp.com                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Without (and the override rule present):
```
$ go run cmd/mal/mal.go --min-risk high --quantity-increases-risk=true  analyze ./out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py
🔎 Scanning "./out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py"
out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/windows/2024.GitHub.Clipper/raw.py [🚨 CRITICAL]
-------------------------------------------------------------------------------------------------------------------------------------------------------------
RISK  KEY                   DESCRIPTION                             EVIDENCE                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------
HIGH  combo/dropper/python  fetch, stores, and execute programs     open(                                                                                    
                                                                    write(                                                                                   
HIGH  ref/site/download     References known file hosting site      cdn.discordapp.com                                                                       
HIGH  ref/site/exe          accesses hardcoded executable endpoint  https://cdn.discordapp.com/attachments/1222129364288671834/1224848705887404072/main.exe  
-------------------------------------------------------------------------------------------------------------------------------------------------------------
```