### PR TITLE
Add override for filebeat misp_sample.ndjson.log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fix: $(FIXERS)
 # END: lint-install ../malcontent
 
 SAMPLES_REPO ?= chainguard-dev/malcontent-samples
-SAMPLES_COMMIT ?= 83f0693557b748ab4c395bdd749b85876fa53e92
+SAMPLES_COMMIT ?= e9dfc70e3107e3e2e6c41c05f7becfee500548f5
 OUT_DIR=out/samples-$(SAMPLES_COMMIT).tmp
 out/samples-$(SAMPLES_COMMIT):
 	mkdir -p out

--- a/rules/false_positives/filebeat.yara
+++ b/rules/false_positives/filebeat.yara
@@ -1,0 +1,12 @@
+rule misp_mdjson : override {
+  meta:
+    description = "misp_sample.mdjson.log"
+    lvt = "medium"
+  strings:
+    $attribute = "Attribute"
+    $event = "Event"
+    $galaxy = "Galaxy"
+    $shadow = "ShadowAttribute"
+  condition:
+    all of them
+}

--- a/test_data/linux/clean/misp_sample.ndjson.log.simple
+++ b/test_data/linux/clean/misp_sample.ndjson.log.simple
@@ -1,0 +1,12 @@
+# linux/clean/misp_sample.ndjson.log: critical
+3P/threat_hunting/pastebin: medium
+crypto/aes: low
+fd/multiplex: low
+ref/ip: medium
+ref/site/download: high
+ref/site/php: medium
+ref/site/url: low
+ref/words/backdoor: high
+ref/words/decryptor: medium
+ref/words/ransomware/lvt: medium
+ref/words/rootkit: high


### PR DESCRIPTION
This PR addresses a false positive we saw with the latest version of filebeat. 

The finding resides in a `.log` file that contains rows of arbitrary JSON content so I added several, somewhat unqiue field strings for the condition.