### PR TITLE
walk: log error instead of returning an error

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -35,7 +35,7 @@ var (
 )
 
 // findFilesRecursively returns a list of files found recursively within a path.
-func findFilesRecursively(_ context.Context, rootPath string) ([]string, error) {
+func findFilesRecursively(ctx context.Context, rootPath string) ([]string, error) {
 	var files []string
 
 	// Follow symlink if provided at the root
@@ -49,10 +49,13 @@ func findFilesRecursively(_ context.Context, rootPath string) ([]string, error) 
 		}
 	}
 
+	logger := clog.FromContext(ctx)
+
 	err = filepath.WalkDir(root,
 		func(path string, info os.DirEntry, err error) error {
 			if err != nil {
-				return fmt.Errorf("walk: %w", err)
+				logger.Errorf("error: %s: %s", path, err)
+				return nil
 			}
 			if info.IsDir() || strings.Contains(path, "/.git/") {
 				return nil


### PR DESCRIPTION
Previously, if walk was unable to traverse a directory, it would exit without scanning any files:

```
🔎 Scanning "/etc"
error: scan: find: walk: open /etc/credstore: permission denied
exit status 2
```


With this PR, it just logs noisy error messages and keeps on trucking:

```
🔎 Scanning "/etc"
time=2024-10-23T20:53:27.491-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/credstore: open /etc/credst
ore: permission denied"
time=2024-10-23T20:53:27.491-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/credstore.encrypted: open /
etc/credstore.encrypted: permission denied"
time=2024-10-23T20:53:27.492-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/multipath: open /etc/multip
ath: permission denied"
time=2024-10-23T20:53:27.492-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/polkit-1/rules.d: open /etc
/polkit-1/rules.d: permission denied"
time=2024-10-23T20:53:27.493-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/ssl/private: open /etc/ssl/
private: permission denied"
time=2024-10-23T20:53:27.493-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:57 msg="error: /etc/sudoers.d: open /etc/sudoer
s.d: permission denied"
time=2024-10-23T20:53:27.494-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:100 msg="file type failure: /etc/.pwd.lock: ope
n: open /etc/.pwd.lock: permission denied" path=/etc/.pwd.lock
````

