### PR TITLE
Cleanly handle no-op third-party rule Workflow runs

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -42,7 +42,12 @@ jobs:
       - name: Run make refresh-test-data
         run: |
           make refresh-sample-testdata
+      - name: Retrieve changes
+        id: check
+        run: |
+          echo "CHANGES=$(git status -s | wc -l)" >> $GITHUB_OUTPUT
       - name: Add and commit changes
+        if: ${{ steps.check.outputs.CHANGES }} > 0
         id: commit
         run: |
           DATE=$(date +%F)
@@ -54,6 +59,7 @@ jobs:
 
           echo "DATE=${DATE}" >> $GITHUB_OUTPUT
       - name: Create Pull Request
+        if: ${{ steps.check.outputs.CHANGES }} > 0
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |


### PR DESCRIPTION
This should be the last tweak for the third-party rule update Workflow. If the Git state is clean after the two Makefile targets run, we don't need to commit the changes or create a PR (doing so generates an error).