### PR TITLE
Simplify commit and PR steps for third-party Workflow

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -42,26 +42,15 @@ jobs:
       - name: Run make refresh-test-data
         run: |
           make refresh-sample-testdata
-      - name: Retrieve changes
-        id: check
+      - name: Commit changes and create PR
         run: |
-          echo "CHANGES=$(git status -s | wc -l)" >> $GITHUB_OUTPUT
-      - name: Add and commit changes
-        if: ${{ steps.check.outputs.CHANGES }} > 0
-        id: commit
-        run: |
-          DATE=$(date +%F)
-          BRANCH="third-party-rule-update-${DATE}"
-          git checkout -b $BRANCH
-          git add .
-          git commit -m "Update third-party rules as of ${DATE}"
-          git push origin $BRANCH
+          if [[ -n $(git status -s) ]]; then
+            DATE=$(date +%F)
+            BRANCH="third-party-rule-update-${DATE}"
+            git checkout -b $BRANCH
+            git add .
+            git commit -m "Update third-party rules as of ${DATE}"
+            git push origin $BRANCH
 
-          echo "DATE=${DATE}" >> $GITHUB_OUTPUT
-      - name: Create Pull Request
-        if: ${{ steps.check.outputs.CHANGES }} > 0
-        env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: |
-          DATE=${{ steps.commit.outputs.DATE }}
-          gh pr create -t "Update third-party rules as of ${DATE}" -b "${DATE} third-party rule update for malcontent." -B main
+            gh pr create -t "Update third-party rules as of ${DATE}" -b "${DATE} third-party rule update for malcontent." -B main
+          fi


### PR DESCRIPTION
This PR simplifies how the commit/PR steps are handled when updating third-party rules. We know that this check works when handling the `yr fmt` changes and the conditional steps weren't panning out like expected.

I verified that this runs cleanly in my fork:
![CleanShot 2024-11-01 at 09 33 01@2x](https://github.com/user-attachments/assets/7df547a9-05b4-4c53-96f8-c6f3f718f9ee)
