### PR TITLE
fix over-indenting in diff mode

### DIFF
--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -284,7 +284,6 @@ func renderFileSummary(_ context.Context, fr *malcontent.FileReport, w io.Writer
 		}
 
 		// behavior readout per namespace
-		indent += " "
 		for _, b := range bs {
 			_, rest := splitRuleID(b.ID)
 
@@ -300,7 +299,7 @@ func renderFileSummary(_ context.Context, fr *malcontent.FileReport, w io.Writer
 				}
 			}
 
-			prefix := "│"
+			prefix := "│ "
 			bullet := riskEmoji(b.RiskScore)
 			content := fmt.Sprintf("%s%s %s %s", prefix, indent, riskColor(b.RiskLevel, bullet+" "+rest), desc)
 			pc := color.New()


### PR DESCRIPTION
A last-minute change to the terminal UI PR resulted in over-indenting diff's by one space:

Previous:

```
├─ 🟡 Changed: 3CX/libffmpeg.dylib [CRITICAL → MEDIUM]
│     X anti-static [CRITICAL → NONE]
--       🛑 xor/user_agent — XOR'ed user agent, often found in backdoors, by Florian Roth
│     ≡ cryptography [LOW]
│       🟢 aes — Supports AES (Advanced Encryption Standard)
│     ≡ data [MEDIUM]
│       🟡 base64/decode — decode base64 strings: base64_decode
--       🟢 compression/gzip — works with gzip files
│       🟢 encoding/base64 — Supports base64 encoded strings
--       🟢 random/insecure — generate random numbers insecurely
```


New:

```
├─ 🟡 Changed: 3CX/libffmpeg.dylib [CRITICAL → MEDIUM]
│     X anti-static [CRITICAL → NONE]
--      🛑 xor/user_agent — XOR'ed user agent, often found in backdoors, by Florian Roth
│     ≡ cryptography [LOW]
│       🟢 aes — Supports AES (Advanced Encryption Standard)
│     ≡ data [MEDIUM]
│       🟡 base64/decode — decode base64 strings: base64_decode
--      🟢 compression/gzip — works with gzip files
│       🟢 encoding/base64 — Supports base64 encoded strings
--      🟢 random/insecure — generate random numbers insecurely
```

