### PR TITLE
Re-add GH_TOKEN to commit/PR step for third-party rule updates

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -43,6 +43,8 @@ jobs:
         run: |
           make refresh-sample-testdata
       - name: Commit changes and create PR
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           if [[ -n $(git status -s) ]]; then
             DATE=$(date +%F)


### PR DESCRIPTION
This environment variable was omitted when I consolidated the commit/PR steps. We need this to create the PR.