### PR TITLE
Don't store an empty file report for err-first-hit/miss findings

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -337,9 +337,7 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 
 		if err := g.Wait(); err != nil {
 			logger.Errorf("error with processing %v\n", err)
-			if strings.Contains(err.Error(), "no matching capabilities") {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		var pathKeys []string
@@ -447,6 +445,9 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
 	r, err := recursiveScan(ctx, c)
 	if err != nil {
+		if strings.Contains(err.Error(), "no matching capabilities") {
+			return r, nil
+		}
 		return r, err
 	}
 	for files := r.Files.Oldest(); files != nil; files = files.Next() {

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -318,6 +318,7 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 					if err := errIfHitOrMiss(&frMap, "file", path, c.ErrFirstHit, c.ErrFirstMiss); err != nil {
 						logger.Debugf("match short circuit: %s", err)
 						scanPathFindings.Store(path, fr)
+						return err
 					}
 				}
 			}
@@ -336,6 +337,9 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 
 		if err := g.Wait(); err != nil {
 			logger.Errorf("error with processing %v\n", err)
+			if strings.Contains(err.Error(), "no matching capabilities") {
+				return nil, err
+			}
 		}
 
 		var pathKeys []string

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -317,7 +317,7 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 					frMap.Store(path, fr)
 					if err := errIfHitOrMiss(&frMap, "file", path, c.ErrFirstHit, c.ErrFirstMiss); err != nil {
 						logger.Debugf("match short circuit: %s", err)
-						scanPathFindings.Store(path, &malcontent.FileReport{})
+						scanPathFindings.Store(path, fr)
 					}
 				}
 			}


### PR DESCRIPTION
This should resolve #577 -- since `errIfHitOrMiss` is supposed to return an error depending on whether `--err-first-hit` or `--err-first-miss` is used, we need to store the original file report in the findings map.

With this change:
```
$ go run cmd/mal/mal.go --err-first-hit scan out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/linux/2024.Kaiji/
🔎 Scanning "out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/linux/2024.Kaiji/"
├─ 🛑 out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/linux/2024.Kaiji/eight-nebraska-autumn-illinois
│     • impact/remote_access/systemctl — systemctl botnet client:
│     .bash_history, Mozilla/5.0, SELINUX, crontab, daemon-reload, id_rsa, known_hosts
│     • malware/family/kaiji — Kaiji IOT Malware: audit2allow -M my-Systemimgconf, chaos_cve_make, systemctl start linux.service
│     • persist/cron/hidden_tab — persists via a hidden crontab entry: */1 * * * * root /.img

💡 For detailed analysis, try "mal analyze <path>"
```

`--err-first-miss` looks like it's functioning as expected, however:
```
$ go run cmd/mal/mal.go --err-first-miss --verbose scan out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean
...
time=2024-11-04T07:31:45.623-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/idna/setup.py file"
time=2024-11-04T07:31:45.623-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/google-auth-library-python/setup.py file"
time=2024-11-04T07:31:45.624-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:106 msg="skipping out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/discovery.py.simple [<unknown>]: data file or empty" path=out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/discovery.py.simple
time=2024-11-04T07:31:45.624-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/discovery.py.simple file"
time=2024-11-04T07:31:45.624-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/ml_sdk/setup.py file"
time=2024-11-04T07:31:45.624-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/magic_trace/magic_trace.py file"
time=2024-11-04T07:31:45.624-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:106 msg="skipping out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/easy_install.py.simple [<unknown>]: data file or empty" path=out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/easy_install.py.simple
time=2024-11-04T07:31:45.624-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/easy_install.py.simple file"
time=2024-11-04T07:31:45.624-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:106 msg="skipping out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/package_index.py.simple [<unknown>]: data file or empty" path=out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/package_index.py.simple
time=2024-11-04T07:31:45.624-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/package_index.py.simple file"
time=2024-11-04T07:31:45.625-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/gevent/test__monkey.py file"
time=2024-11-04T07:31:45.625-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:106 msg="skipping out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/sandbox.py.simple [<unknown>]: data file or empty" path=out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/sandbox.py.simple
time=2024-11-04T07:31:45.625-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/sandbox.py.simple file"
time=2024-11-04T07:31:45.625-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/fonttools/psLib.py file"
time=2024-11-04T07:31:45.625-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:106 msg="skipping out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/tensorflow_model_analysis/tfjs_predict_extractor_util.py.simple [<unknown>]: data file or empty" path=out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/tensorflow_model_analysis/tfjs_predict_extractor_util.py.simple
time=2024-11-04T07:31:45.625-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/tensorflow_model_analysis/tfjs_predict_extractor_util.py.simple file"
time=2024-11-04T07:31:45.625-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/requests/setup.py file"
time=2024-11-04T07:31:45.627-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/jaraco/__init__.py file"
time=2024-11-04T07:31:45.627-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/tensorflow_model_analysis/tfjs_predict_extractor_util.py file"
time=2024-11-04T07:31:45.627-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/pyparsing/sparser.py file"
time=2024-11-04T07:31:45.628-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/discovery.py file"
time=2024-11-04T07:31:45.630-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/sandbox.py file"
time=2024-11-04T07:31:45.638-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/package_index.py file"
time=2024-11-04T07:31:45.646-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/numpy/misc_util.py file"
time=2024-11-04T07:31:45.651-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/easy_install.py file"
time=2024-11-04T07:31:45.775-06:00 level=DEBUG source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:319 msg="match short circuit: no matching capabilities in out/samples-0ff28cbe99bc4610c58016faeb1a806a6e5cebbb/python/clean/setuptools/build_meta.py file"

💡 For detailed analysis, try "mal analyze <path>"
```