### PR TITLE
Makefile: Add Linux support for yara-x linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ else
 	LINT_PLATFORM=unknown
 endif
 
+
+LINT_PLATFOM_SUFFIX :=
+ifeq ($(LINT_OS),Linux)
+	LINT_PLATFORM_SUFFIX=-gnu
+endif
+
+
 LINTERS :=
 FIXERS :=
 
@@ -40,11 +47,11 @@ $(GOLANGCI_LINT_BIN):
 	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
 YARA_X_VERSION ?= v0.10.0
-YARA_X_BIN := $(LINT_ROOT)/out/linters/yr
+YARA_X_BIN := $(LINT_ROOT)/out/linters/yr-$(YARA_X_VERSION)-$(LINT_ARCH)
 $(YARA_X_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters
 	rm -rf $(LINT_ROOT)/out/linters/yr
-	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER).gzip -o yara-x.gzip
+	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER)$(LINT_PLATFORM_SUFFIX).gzip -o yara-x.gzip
 	tar -xzvf yara-x.gzip && mv yr $(LINT_ROOT)/out/linters && rm yara-x.gzip
 	mv $(LINT_ROOT)/out/linters/yr $@
 


### PR DESCRIPTION
Previously it was downloading the incorrect URL.

Also, fix it so that it versions the downloaded binary appropriately.
