### PR TITLE
Improve --err-first-hit handling

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -409,7 +409,7 @@ func main() {
 						ps, err := action.ActiveProcesses(ctx)
 						if err != nil {
 							returnCode = ExitActionFailed
-							return fmt.Errorf("process paths: %w", err)
+							return err
 						}
 						for _, p := range ps {
 							// in the future, we'll also want to attach process info directly
@@ -419,9 +419,9 @@ func main() {
 
 					res, err = action.Scan(ctx, mc)
 					if err != nil {
+
 						returnCode = ExitActionFailed
-						showError(err)
-						return nil
+						return err
 					}
 
 					err = renderer.Full(ctx, res)
@@ -542,7 +542,13 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		returnCode = ExitActionFailed
+		if returnCode != 0 {
+			returnCode = ExitActionFailed
+		}
+		if errors.Is(err, action.ErrMatchedCondition) {
+			returnCode = ExitOK
+		}
+
+		showError(err)
 	}
 }

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -78,6 +79,16 @@ var riskMap = map[string]int{
 	"4":        4,
 	"crit":     4,
 	"critical": 4,
+}
+
+func showError(err error) {
+	emoji := "💣"
+	if errors.Is(err, action.ErrMatchedCondition) {
+		emoji = "👋"
+		err = errors.Unwrap(err)
+	}
+
+	fmt.Fprintf(os.Stderr, "%s %s\n", emoji, err.Error())
 }
 
 //nolint:cyclop // ignore complexity of 40
@@ -409,7 +420,8 @@ func main() {
 					res, err = action.Scan(ctx, mc)
 					if err != nil {
 						returnCode = ExitActionFailed
-						return fmt.Errorf("scan: %w", err)
+						showError(err)
+						return nil
 					}
 
 					err = renderer.Full(ctx, res)

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -419,7 +419,6 @@ func main() {
 
 					res, err = action.Scan(ctx, mc)
 					if err != nil {
-
 						returnCode = ExitActionFailed
 						return err
 					}

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -403,7 +403,6 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 		if waitErr != nil {
 			return r, waitErr
 		}
-
 	} // loop: next scan path
 	return r, nil
 }

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -468,7 +468,7 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
 	r, err := recursiveScan(ctx, c)
 	if err != nil {
-		return r, fmt.Errorf("recursive: %w", err)
+		return r, err
 	}
 	for files := r.Files.Oldest(); files != nil; files = files.Next() {
 		if files.Value.RiskScore < c.MinFileRisk {


### PR DESCRIPTION
Currently, if `--err-first-hit` is used, it hides the normal view of matching behaviors:

```
% go run ./cmd/mal --err-first-hit scan /usr/bin/V*

🔎 Scanning "/usr/bin/VBoxClient"
time=2024-11-06T16:38:22.740-05:00 level=ERROR source=/var/home/t/src/malcontent/pkg/action/scan.go:354 msg="error with processing 1 matching capabilities in /usr/bin/VBoxClient file: impact/remote_access/backdoor\n"
error: scan: 1 matching capabilities in /usr/bin/VBoxClient file: impact/remote_access/backdoor
exit status 2
```

With this PR, the usual output is displayed and the error message is a bit cleaner:

```
🔎 Scanning "/usr/bin/VBoxClient"
├─ 🟠 /usr/bin/VBoxClient
│     • impact/remote_access/backdoor — References a 'BACKDOOR': GROUP_DEV_VMM_BACKDOOR
🔎 Scanning "/usr/bin/VBoxClient-all"
👋 "/etc/X11/xinit/xinitrc.d/98vboxadd-xclient.sh": matched requested condition
```

