### PR TITLE
showError: Remove unwrap for ErrMatchedCondition

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -85,7 +85,6 @@ func showError(err error) {
 	emoji := "💣"
 	if errors.Is(err, action.ErrMatchedCondition) {
 		emoji = "👋"
-		err = errors.Unwrap(err)
 	}
 
 	fmt.Fprintf(os.Stderr, "%s %s\n", emoji, err.Error())


### PR DESCRIPTION
In some code paths, this was stripping out the filename.