### PR TITLE
Test larger runners

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: mal-ubuntu-latest-8-core
 
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: mal-ubuntu-latest-8-core
+    runs-on: mal-ubuntu-latest-16-core
 
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: mal-ubuntu-latest-16-core
+    runs-on: mal-ubuntu-latest-64-core
 
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: mal-ubuntu-latest-64-core
+    runs-on: mal-ubuntu-latest-arm-16-core
 
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -35,11 +35,6 @@ jobs:
 
       - name: install dependencies
         run: |
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-updates main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-backports main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://security.ubuntu.com/ubuntu mantic-security main restricted universe multiverse"
-
           sudo apt update && sudo apt install libyara-dev xz-utils -y
 
       - name: Unit tests

--- a/pkg/action/archive_test.go
+++ b/pkg/action/archive_test.go
@@ -39,6 +39,7 @@ func TestExtractionMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := extractionMethod(tt.ext)
 			if (got == nil) != (tt.want == nil) {
 				t.Errorf("extractionMethod() for extension %v did not return expected result", tt.ext)
@@ -48,7 +49,6 @@ func TestExtractionMethod(t *testing.T) {
 }
 
 func TestExtractionMultiple(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		path string
 		want []string
@@ -317,6 +317,7 @@ func TestGetExt(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
 			if got := getExt(tt.path); got != tt.want {
 				t.Errorf("Ext() = %v, want %v", got, tt.want)
 			}

--- a/pkg/action/scan_test.go
+++ b/pkg/action/scan_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCleanPath(t *testing.T) {
+	t.Parallel()
 	// create a temporary directory
 	tempDir, err := os.MkdirTemp("", "TestCleanPath")
 	if err != nil {
@@ -122,6 +123,7 @@ func TestFormatPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := formatPath(tt.path); got != tt.want {
 				t.Errorf("FormatPath() = %v, want %v", got, tt.want)
 			}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestProfile(t *testing.T) {
+	t.Parallel()
 	stop, err := Profile()
 	if err != nil {
 		t.Fatalf("failed to start profiling: %v", err)

--- a/pkg/programkind/programkind_test.go
+++ b/pkg/programkind/programkind_test.go
@@ -26,6 +26,7 @@ func TestFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
 			got, err := File(filepath.Join("testdata/", tt.in))
 			if err != nil {
 				t.Errorf("File(%s) returned error: %v", tt.in, err)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -41,6 +41,7 @@ func TestLongestUnique(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := longestUnique(tt.raw); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("longestUnique() = %v, want %v", got, tt.want)
 			}
@@ -82,6 +83,7 @@ func TestUpgradeRisk(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := upgradeRisk(context.Background(), tt.currentScore, tt.riskCounts, tt.size); got != tt.want {
 				t.Errorf("upgradeRisk(%d, %v, %v) = %v, want %v", tt.currentScore, tt.riskCounts, tt.size, got, tt.want)
 			}


### PR DESCRIPTION
Using this PR to test 8- and 16-core runners now that our tests scale with core count. These are rough estimates since I haven't performed multiple runs on each size.
4-core (previous PR with the fix):
```
$ go test -timeout 0 ./tests/...
ok  	github.com/chainguard-dev/malcontent/tests	391.531s
```

8-core:
```
$ go test -timeout 0 ./tests/...
ok  	github.com/chainguard-dev/malcontent/tests	236.204s
```

16-core ARM:
```
$ go test -timeout 0 ./tests/...
ok  	github.com/chainguard-dev/malcontent/tests	222.552s
```

16-core:
```
$ go test -timeout 0 ./tests/...
ok  	github.com/chainguard-dev/malcontent/tests	174.358s
```

64-cores; definitely hitting diminishing returns:
```
$  go test -timeout 0 ./tests/...
ok  	github.com/chainguard-dev/malcontent/tests	152.434s
```

8 cores seems to be the best tradeoff between performance and cost. 