### PR TITLE
Use 8-core runners for tests and updating third-party rules

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: mal-ubuntu-latest-8-core
 
     steps:
       - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
-    runs-on: ubuntu-latest
+    runs-on: mal-ubuntu-latest-8-core
     permissions:
       contents: write
       id-token: write

--- a/pkg/action/archive_test.go
+++ b/pkg/action/archive_test.go
@@ -39,6 +39,7 @@ func TestExtractionMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := extractionMethod(tt.ext)
 			if (got == nil) != (tt.want == nil) {
 				t.Errorf("extractionMethod() for extension %v did not return expected result", tt.ext)
@@ -48,7 +49,6 @@ func TestExtractionMethod(t *testing.T) {
 }
 
 func TestExtractionMultiple(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		path string
 		want []string
@@ -317,6 +317,7 @@ func TestGetExt(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
 			if got := getExt(tt.path); got != tt.want {
 				t.Errorf("Ext() = %v, want %v", got, tt.want)
 			}

--- a/pkg/action/scan_test.go
+++ b/pkg/action/scan_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCleanPath(t *testing.T) {
+	t.Parallel()
 	// create a temporary directory
 	tempDir, err := os.MkdirTemp("", "TestCleanPath")
 	if err != nil {
@@ -122,6 +123,7 @@ func TestFormatPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := formatPath(tt.path); got != tt.want {
 				t.Errorf("FormatPath() = %v, want %v", got, tt.want)
 			}

--- a/pkg/action/scan_test.go
+++ b/pkg/action/scan_test.go
@@ -8,32 +8,6 @@ import (
 )
 
 func TestCleanPath(t *testing.T) {
-	t.Parallel()
-	// create a temporary directory
-	tempDir, err := os.MkdirTemp("", "TestCleanPath")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// create and symlink a nested directory
-	// create a file within the nested directory
-	nestedDir := filepath.Join(tempDir, "nested")
-	if err := os.Mkdir(nestedDir, 0o755); err != nil {
-		t.Fatalf("failed to create nested directory: %v", err)
-	}
-	symlinkPath := filepath.Join(tempDir, "symlink")
-	if err := os.Symlink(nestedDir, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
-
-	filePath := filepath.Join(nestedDir, "test.txt")
-	file, err := os.Create(filePath)
-	if err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	defer file.Close()
-
 	tests := []struct {
 		name    string
 		path    string
@@ -43,33 +17,33 @@ func TestCleanPath(t *testing.T) {
 	}{
 		{
 			name:   "expected behavior",
-			path:   filepath.Join(nestedDir, "test.txt"),
-			prefix: nestedDir,
+			path:   "nested/test.txt",
+			prefix: "nested",
 			want:   "/test.txt",
 		},
 		{
 			name:   "symlink in path",
-			path:   filepath.Join(symlinkPath, "test.txt"),
-			prefix: nestedDir,
+			path:   "symlink/test.txt",
+			prefix: "nested",
 			want:   "/test.txt",
 		},
 		{
 			name:   "symlink in prefix",
-			path:   filepath.Join(nestedDir, "test.txt"),
-			prefix: symlinkPath,
+			path:   "nested/test.txt",
+			prefix: "symlink",
 			want:   "/test.txt",
 		},
 		{
 			name:    "non-existent path",
-			path:    filepath.Join(tempDir, "does_not_exist", "test.txt"),
-			prefix:  tempDir,
+			path:    "does_not_exist/test.txt",
+			prefix:  "temp",
 			wantErr: true,
 		},
 		{
 			name:   "path prefix mismatch",
-			path:   filepath.Join(nestedDir, "test.txt"),
+			path:   "nested/test.txt",
 			prefix: "",
-			want:   filepath.Join(nestedDir, "test.txt"),
+			want:   "nested/test.txt",
 		},
 		{
 			name:   "empty paths",
@@ -79,20 +53,47 @@ func TestCleanPath(t *testing.T) {
 		},
 		{
 			name:   "identical path and prefix",
-			path:   nestedDir,
-			prefix: nestedDir,
+			path:   "nested",
+			prefix: "nested",
 			want:   "",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cleanPath(tt.path, tt.prefix)
+			t.Parallel()
+
+			tempDir, err := os.MkdirTemp("", "TestCleanPath")
+			if err != nil {
+				t.Fatalf("failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			nestedDir := filepath.Join(tempDir, "nested")
+			if err := os.Mkdir(nestedDir, 0o755); err != nil {
+				t.Fatalf("failed to create nested directory: %v", err)
+			}
+
+			symlinkPath := filepath.Join(tempDir, "symlink")
+			if err := os.Symlink(nestedDir, symlinkPath); err != nil {
+				t.Fatalf("failed to create symlink: %v", err)
+			}
+
+			filePath := filepath.Join(nestedDir, "test.txt")
+			file, err := os.Create(filePath)
+			if err != nil {
+				t.Fatalf("failed to create file: %v", err)
+			}
+			file.Close()
+
+			fullPath := filepath.Join(tempDir, tt.path)
+			fullPrefix := filepath.Join(tempDir, tt.prefix)
+
+			got, err := cleanPath(fullPath, fullPrefix)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("cleanPath() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !strings.HasSuffix(got, tt.want) {
+			if !tt.wantErr && !strings.HasSuffix(got, tt.want) {
 				t.Errorf("cleanPath() = %v, want suffix %v", got, tt.want)
 			}
 		})

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestProfile(t *testing.T) {
+	t.Parallel()
 	stop, err := Profile()
 	if err != nil {
 		t.Fatalf("failed to start profiling: %v", err)

--- a/pkg/programkind/programkind_test.go
+++ b/pkg/programkind/programkind_test.go
@@ -26,6 +26,7 @@ func TestFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
 			got, err := File(filepath.Join("testdata/", tt.in))
 			if err != nil {
 				t.Errorf("File(%s) returned error: %v", tt.in, err)

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -41,6 +41,7 @@ func TestLongestUnique(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := longestUnique(tt.raw); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("longestUnique() = %v, want %v", got, tt.want)
 			}
@@ -82,6 +83,7 @@ func TestUpgradeRisk(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := upgradeRisk(context.Background(), tt.currentScore, tt.riskCounts, tt.size); got != tt.want {
 				t.Errorf("upgradeRisk(%d, %v, %v) = %v, want %v", tt.currentScore, tt.riskCounts, tt.size, got, tt.want)
 			}


### PR DESCRIPTION
With all of our tests using `t.Parallel()` appropriately, we can leverage a larger runner to further cut down on how long our tests take.

Based on https://github.com/chainguard-dev/malcontent/pull/632, 8-core runners offer a sizable performance uplift over the default 4-core runners and anything larger hits the realm of diminishing returns pretty quickly.

![image](https://github.com/user-attachments/assets/f67a87a6-2a6c-458f-af31-51ac6b8aebf3)
This definitely beats the 12-13+ minute Workflow runs we were seeing originally.