### PR TITLE
Add flag to ignore problematic file extensions

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -52,6 +52,7 @@ var (
 	fileRiskChangeFlag        bool
 	fileRiskIncreaseFlag      bool
 	formatFlag                string
+	ignoreExtsFlag            string
 	ignoreSelfFlag            bool
 	ignoreTagsFlag            string
 	includeDataFilesFlag      bool
@@ -243,6 +244,7 @@ func main() {
 				Concurrency:           concurrencyFlag,
 				ExitFirstHit:          exitFirstHitFlag,
 				ExitFirstMiss:         exitFirstMissFlag,
+				IgnoreExts:            ignoreExtsFlag,
 				IgnoreSelf:            ignoreSelfFlag,
 				IgnoreTags:            ignoreTags,
 				IncludeDataFiles:      includeDataFiles,
@@ -283,6 +285,12 @@ func main() {
 				Value:       "auto",
 				Usage:       "Output format (json, markdown, simple, strings, terminal, yaml)",
 				Destination: &formatFlag,
+			},
+			&cli.StringFlag{
+				Name:        "ignore-exts",
+				Value:       "",
+				Usage:       "Ignore specific file extensions when scanning",
+				Destination: &ignoreExtsFlag,
 			},
 			&cli.BoolFlag{
 				Name:        "ignore-self",

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -97,6 +97,17 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 
 	isArchive := archiveRoot != ""
 
+	var exts []string
+	if c.IgnoreExts != "" {
+		exts = strings.Split(c.IgnoreExts, ",")
+		for _, ext := range exts {
+			if ext == getExt(path) {
+				logger.Infof("skipping %s [%s]: ignored file extension", path, ext)
+				return &malcontent.FileReport{Skipped: "ignored file extension", Path: path}, nil
+			}
+		}
+	}
+
 	mime := "<unknown>"
 	kind, err := programkind.File(path)
 	if err != nil {

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -26,6 +26,7 @@ type Config struct {
 	ExitFirstMiss         bool
 	FileRiskChange        bool
 	FileRiskIncrease      bool
+	IgnoreExts            string
 	IgnoreSelf            bool
 	IgnoreTags            []string
 	IncludeDataFiles      bool


### PR DESCRIPTION
Relates to: #587

We're failing to scan certain files that are essentially one long string. Scanning these files with our compiled ruleset seems to be too much for the Yara library and results in this error:
```
💣 process: report error: scan: too many regular expression fibers
```

This PR adds a new flag to ignore certain file extensions that cause this error to work around this for the time being.

Example:
```
$ go run cmd/mal/mal.go --verbose --ignore-exts=.map analyze ~/Downloads/prism/usr/src/prism/node_modules/micri/dist/index.js.map
🔎 Scanning ".../Downloads/prism/usr/src/prism/node_modules/micri/dist/index.js.map"
time=2024-11-18T17:29:18.025-06:00 level=INFO source=.../repos/chainguard-dev/malcontent/pkg/action/scan.go:105 msg="skipping .../Downloads/prism/usr/src/prism/node_modules/micri/dist/index.js.map [.map]: ignored file extension" path.../Downloads/prism/usr/src/prism/node_modules/micri/dist/index.js.map
```

We'll continue looking into handling files like this in a more resilient way.