### PR TITLE
Use CachedRules in tests similarly to refresh

### DIFF
--- a/pkg/action/archive_test.go
+++ b/pkg/action/archive_test.go
@@ -233,7 +233,6 @@ func TestScanArchive(t *testing.T) {
 		MinFileRisk: 0,
 		MinRisk:     0,
 		Renderer:    r,
-		RuleFS:      rfs,
 		Rules:       yrs,
 		ScanPaths:   []string{"testdata/apko_nested.tar.gz"},
 	}

--- a/pkg/action/archive_test.go
+++ b/pkg/action/archive_test.go
@@ -221,16 +221,23 @@ func TestScanArchive(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 
-	bc := malcontent.Config{
+	rfs := []fs.FS{rules.FS, thirdparty.FS}
+	yrs, err := CachedRules(ctx, rfs)
+	if err != nil {
+		t.Fatalf("rules: %v", err)
+	}
+
+	mc := malcontent.Config{
 		Concurrency: runtime.NumCPU(),
 		IgnoreSelf:  false,
 		MinFileRisk: 0,
 		MinRisk:     0,
 		Renderer:    r,
-		RuleFS:      []fs.FS{rules.FS, thirdparty.FS},
+		RuleFS:      rfs,
+		Rules:       yrs,
 		ScanPaths:   []string{"testdata/apko_nested.tar.gz"},
 	}
-	res, err := Scan(ctx, bc)
+	res, err := Scan(ctx, mc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/oci_test.go
+++ b/pkg/action/oci_test.go
@@ -27,16 +27,23 @@ func TestOCI(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 
-	bc := malcontent.Config{
+	rfs := []fs.FS{rules.FS, thirdparty.FS}
+	yrs, err := CachedRules(ctx, rfs)
+	if err != nil {
+		t.Fatalf("rules: %v", err)
+	}
+
+	mc := malcontent.Config{
 		Concurrency: runtime.NumCPU(),
 		IgnoreSelf:  false,
 		MinFileRisk: 0,
 		MinRisk:     0,
 		Renderer:    r,
+		Rules:       yrs,
 		RuleFS:      []fs.FS{rules.FS, thirdparty.FS},
 		ScanPaths:   []string{"testdata/static.tar.xz"},
 	}
-	res, err := Scan(ctx, bc)
+	res, err := Scan(ctx, mc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/oci_test.go
+++ b/pkg/action/oci_test.go
@@ -40,7 +40,6 @@ func TestOCI(t *testing.T) {
 		MinRisk:     0,
 		Renderer:    r,
 		Rules:       yrs,
-		RuleFS:      []fs.FS{rules.FS, thirdparty.FS},
 		ScanPaths:   []string{"testdata/static.tar.xz"},
 	}
 	res, err := Scan(ctx, mc)

--- a/pkg/refresh/action.go
+++ b/pkg/refresh/action.go
@@ -72,7 +72,6 @@ func actionRefresh(ctx context.Context) ([]TestData, error) {
 			OCI:                   false,
 			QuantityIncreasesRisk: true,
 			Renderer:              r,
-			RuleFS:                rfs,
 			Rules:                 yrs,
 			ScanPaths:             []string{scan},
 			TrimPrefixes:          []string{"pkg/action/"},

--- a/pkg/refresh/diff.go
+++ b/pkg/refresh/diff.go
@@ -199,7 +199,6 @@ func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 			QuantityIncreasesRisk: true,
 			Renderer:              renderer,
 			Rules:                 yrs,
-			RuleFS:                rfs,
 			ScanPaths:             []string{src, dest},
 			TrimPrefixes:          []string{rc.SamplesPath},
 		}

--- a/tests/samples_test.go
+++ b/tests/samples_test.go
@@ -90,13 +90,20 @@ func TestJSON(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency: runtime.NumCPU(),
 				IgnoreSelf:  false,
 				MinFileRisk: 1,
 				MinRisk:     1,
 				Renderer:    render,
-				RuleFS:      []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:      rfs,
+				Rules:       yrs,
 				ScanPaths:   []string{binPath},
 			}
 
@@ -158,6 +165,12 @@ func TestSimple(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency:           runtime.NumCPU(),
 				IgnoreSelf:            false,
@@ -166,7 +179,8 @@ func TestSimple(t *testing.T) {
 				MinRisk:               1,
 				QuantityIncreasesRisk: true,
 				Renderer:              simple,
-				RuleFS:                []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:                rfs,
+				Rules:                 yrs,
 				ScanPaths:             []string{binPath},
 			}
 
@@ -231,6 +245,12 @@ func TestDiff(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency: runtime.NumCPU(),
 				IgnoreSelf:  false,
@@ -238,7 +258,8 @@ func TestDiff(t *testing.T) {
 				MinFileRisk: tc.minFileScore,
 				MinRisk:     tc.minResultScore,
 				Renderer:    simple,
-				RuleFS:      []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:      rfs,
+				Rules:       yrs,
 				ScanPaths:   []string{tc.src, tc.dest},
 			}
 
@@ -297,6 +318,12 @@ func TestDiffFileChange(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency:    runtime.NumCPU(),
 				FileRiskChange: true,
@@ -305,7 +332,8 @@ func TestDiffFileChange(t *testing.T) {
 				MinFileRisk:    tc.minFileScore,
 				MinRisk:        tc.minResultScore,
 				Renderer:       simple,
-				RuleFS:         []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:         rfs,
+				Rules:          yrs,
 				ScanPaths:      []string{strings.TrimPrefix(tc.src, "../out/chainguard-dev/malcontent-samples/"), strings.TrimPrefix(tc.dest, "../out/chainguard-dev/malcontent-samples/")},
 			}
 
@@ -364,6 +392,12 @@ func TestDiffFileIncrease(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency:      runtime.NumCPU(),
 				FileRiskIncrease: true,
@@ -372,7 +406,8 @@ func TestDiffFileIncrease(t *testing.T) {
 				MinFileRisk:      tc.minFileScore,
 				MinRisk:          tc.minResultScore,
 				Renderer:         simple,
-				RuleFS:           []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:           rfs,
+				Rules:            yrs,
 				ScanPaths:        []string{strings.TrimPrefix(tc.src, "../out/chainguard-dev/malcontent-samples/"), strings.TrimPrefix(tc.dest, "../out/chainguard-dev/malcontent-samples/")},
 			}
 
@@ -463,6 +498,12 @@ func TestMarkdown(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 
+			rfs := []fs.FS{rules.FS, thirdparty.FS}
+			yrs, err := action.CachedRules(ctx, rfs)
+			if err != nil {
+				t.Fatalf("rules: %v", err)
+			}
+
 			mc := malcontent.Config{
 				Concurrency:           runtime.NumCPU(),
 				IgnoreSelf:            false,
@@ -471,7 +512,8 @@ func TestMarkdown(t *testing.T) {
 				MinRisk:               1,
 				QuantityIncreasesRisk: true,
 				Renderer:              simple,
-				RuleFS:                []fs.FS{rules.FS, thirdparty.FS},
+				RuleFS:                rfs,
+				Rules:                 yrs,
 				ScanPaths:             []string{binPath},
 			}
 

--- a/tests/samples_test.go
+++ b/tests/samples_test.go
@@ -106,7 +106,6 @@ func TestJSON(t *testing.T) {
 				MinFileRisk: 1,
 				MinRisk:     1,
 				Renderer:    render,
-				RuleFS:      rfs,
 				Rules:       yrs,
 				ScanPaths:   []string{binPath},
 			}
@@ -177,7 +176,6 @@ func TestSimple(t *testing.T) {
 				MinRisk:               1,
 				QuantityIncreasesRisk: true,
 				Renderer:              simple,
-				RuleFS:                rfs,
 				Rules:                 yrs,
 				ScanPaths:             []string{binPath},
 			}
@@ -250,7 +248,6 @@ func TestDiff(t *testing.T) {
 				MinFileRisk: tc.minFileScore,
 				MinRisk:     tc.minResultScore,
 				Renderer:    simple,
-				RuleFS:      rfs,
 				Rules:       yrs,
 				ScanPaths:   []string{tc.src, tc.dest},
 			}
@@ -318,7 +315,6 @@ func TestDiffFileChange(t *testing.T) {
 				MinFileRisk:    tc.minFileScore,
 				MinRisk:        tc.minResultScore,
 				Renderer:       simple,
-				RuleFS:         rfs,
 				Rules:          yrs,
 				ScanPaths:      []string{strings.TrimPrefix(tc.src, "../out/chainguard-dev/malcontent-samples/"), strings.TrimPrefix(tc.dest, "../out/chainguard-dev/malcontent-samples/")},
 			}
@@ -386,7 +382,6 @@ func TestDiffFileIncrease(t *testing.T) {
 				MinFileRisk:      tc.minFileScore,
 				MinRisk:          tc.minResultScore,
 				Renderer:         simple,
-				RuleFS:           rfs,
 				Rules:            yrs,
 				ScanPaths:        []string{strings.TrimPrefix(tc.src, "../out/chainguard-dev/malcontent-samples/"), strings.TrimPrefix(tc.dest, "../out/chainguard-dev/malcontent-samples/")},
 			}
@@ -486,7 +481,6 @@ func TestMarkdown(t *testing.T) {
 				MinRisk:               1,
 				QuantityIncreasesRisk: true,
 				Renderer:              simple,
-				RuleFS:                rfs,
 				Rules:                 yrs,
 				ScanPaths:             []string{binPath},
 			}
@@ -565,7 +559,6 @@ func Template(b *testing.B, paths []string) func() {
 			IgnoreSelf:  true,
 			IgnoreTags:  []string{"harmless"},
 			Renderer:    simple,
-			RuleFS:      rfs,
 			Rules:       yrs,
 			ScanPaths:   paths,
 		}


### PR DESCRIPTION
We can leverage `CachedRules` across our parallel tests to save additional time like we do for `mal refresh`. It's nothing earth-shattering but it was saving ~5 seconds for me locally.