### PR TITLE
Correctly calculate statistics when running scans

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -343,7 +343,7 @@ func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report
 					if k, ok := key.(string); ok {
 						if fr, ok := value.(*malcontent.FileReport); ok {
 							if len(c.TrimPrefixes) > 0 {
-								path = report.TrimPrefixes(k, c.TrimPrefixes)
+								k = report.TrimPrefixes(k, c.TrimPrefixes)
 							}
 							r.Files.Store(k, fr)
 							if c.Renderer != nil && r.Diff == nil && fr.RiskScore >= c.MinFileRisk {
@@ -562,7 +562,7 @@ func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) 
 		return true
 	})
 	if c.Stats {
-		err = render.Statistics(r)
+		err = render.Statistics(&c, r)
 		if err != nil {
 			return r, fmt.Errorf("stats: %w", err)
 		}

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -44,7 +44,7 @@ func matchFragmentLink(s string) string {
 func (r Markdown) Scanning(_ context.Context, _ string) {}
 
 func (r Markdown) File(ctx context.Context, fr *malcontent.FileReport) error {
-	if len(fr.Behaviors) > 0 {
+	if fr.Skipped == "" && len(fr.Behaviors) > 0 {
 		markdownTable(ctx, fr, r.w, tableConfig{Title: fmt.Sprintf("## %s [%s]", fr.Path, mdRisk(fr.RiskScore, fr.RiskLevel))})
 	}
 	return nil

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -78,7 +78,7 @@ func (r StringMatches) Scanning(_ context.Context, path string) {
 }
 
 func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error {
-	if len(fr.Behaviors) == 0 {
+	if fr.Skipped != "" || len(fr.Behaviors) == 0 {
 		return nil
 	}
 

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -80,7 +80,7 @@ func (r Terminal) Scanning(_ context.Context, path string) {
 }
 
 func (r Terminal) File(ctx context.Context, fr *malcontent.FileReport) error {
-	if len(fr.Behaviors) > 0 {
+	if fr.Skipped == "" && len(fr.Behaviors) > 0 {
 		renderFileSummary(ctx, fr, r.w,
 			tableConfig{
 				Title: fmt.Sprintf("%s %s", fr.Path, darkBrackets(riskInColor(fr.RiskLevel))),
@@ -225,6 +225,10 @@ func renderFileSummary(_ context.Context, fr *malcontent.FileReport, w io.Writer
 	nsRiskScore := map[string]int{}
 	previousNsRiskScore := map[string]int{}
 	diffMode := false
+
+	if fr.Skipped != "" {
+		return
+	}
 
 	for _, b := range fr.Behaviors {
 		ns, _ := splitRuleID(b.ID)

--- a/pkg/render/terminal_brief.go
+++ b/pkg/render/terminal_brief.go
@@ -33,7 +33,7 @@ func (r TerminalBrief) Scanning(_ context.Context, path string) {
 }
 
 func (r TerminalBrief) File(_ context.Context, fr *malcontent.FileReport) error {
-	if len(fr.Behaviors) == 0 {
+	if fr.Skipped != "" || len(fr.Behaviors) == 0 {
 		return nil
 	}
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -406,7 +406,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 	if c.Scan {
 		highestRisk = highestMatchRisk(mrs)
 		if highestRisk < 3 {
-			return malcontent.FileReport{}, nil
+			fr.Skipped = "overall risk too low for scan"
 		}
 	}
 
@@ -592,14 +592,14 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c malconten
 	}
 
 	if c.Scan && overallRiskScore < HIGH {
-		return malcontent.FileReport{}, nil
+		fr.Skipped = "overall risk too low for scan"
 	}
 
 	// Check for both the full and shortened variants of malcontent
 	isMalBinary := (filepath.Base(path) == NAME || filepath.Base(path) == "mal")
 
 	if all(ignoreSelf, fr.IsMalcontent, ignoreMalcontent, isMalBinary) {
-		return malcontent.FileReport{}, nil
+		fr.Skipped = "ignoring malcontent binary"
 	}
 
 	// If something has a lot of high, it's probably critical


### PR DESCRIPTION
Addresses #648

Running a `scan` would drop any file report whose risk was < `HIGH`. This threw off `--stats` since we'd only calculate the percentage of critical and high risks from the number of file reports matching those severities.

This PR tweaks the report and statistics logic so that we have the same number of files that `analyze` would have.

Example:
```
$ go run cmd/mal/mal.go --stats scan ./out/chainguard-dev/malcontent-samples/python/
...
📊 Statistics
---
Files Scanned   89 (48 skipped)
Total Risks     41
---
⚠️  Risk Level Percentage
---
Risk Level    Percentage Count/Total
4/CRIT            39.33% 35/89
3/HIGH             6.74% 6/89
---
Number of behaviors         72
...
```

`Files Scanned` matches what `analyze` sees:
```
$ go run cmd/mal/mal.go --stats analyze ./out/chainguard-dev/malcontent-samples/python/
📊 Statistics
---
Files Scanned   89 (0 skipped)
Total Risks     89
---
⚠️  Risk Level Percentage
---
Risk Level    Percentage Count/Total
2/MED             44.94% 40/89
4/CRIT            39.33% 35/89
1/LOW              8.99% 8/89
3/HIGH             6.74% 6/89
---
Number of behaviors        962
...
```