### PR TITLE
Add script to find missing testdata

### DIFF
--- a/tests/find-missing-testdata.sh
+++ b/tests/find-missing-testdata.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# find missing testdata
+#
+# usage:
+#   ./missing-testdata.sh </path/to/SAMPLE_DIR>
+#
+
+set -e -u -o pipefail
+SAMPLE_DIR=${1:-"$(dirname $0)/../../malcontent-samples"}
+
+SAMPLE_DIR=$(realpath ${SAMPLE_DIR})
+
+if [[ ! -d "${SAMPLE_DIR}/does-nothing" ]]; then
+	echo "${SAMPLE_DIR} does not appear to be a valid sample directory, please pass one in on the command-line"
+	exit 1
+fi
+
+for sample_path in $(find "${SAMPLE_DIR}/" -type f -size +100c); do
+	if [[ "${sample_path}" =~ ".git" ]]; then
+		continue
+	fi
+
+	if [[ "${sample_path}" =~ "README" ]]; then
+		continue
+	fi
+
+	if [[ "${sample_path}" =~ ".txt" ]]; then
+		continue
+	fi
+
+	if [[ "${sample_path}" =~ "LICENSE" ]]; then
+		continue
+	fi
+
+	basename="${sample_path/${SAMPLE_DIR}\//}"
+	basename="${basename%\.xz}"
+	relative="./${basename}"
+	found=0
+	for test_path in "${relative}".*; do
+		if [[ -f "${test_path}" ]]; then
+			found=1
+		fi
+	done
+
+	if [[ "${found}" -eq 0 ]]; then
+		dir=$(dirname ${relative})
+		if [[ ! -d "${dir}" ]]; then
+			echo "mkdir -p ${dir} && touch ${relative}.simple"
+		else
+			echo "touch ${relative}.simple"
+		fi
+	fi
+done

--- a/tests/find-missing-testdata.sh
+++ b/tests/find-missing-testdata.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# find missing testdata
+# helper script to find samples with missing testdata
 #
 # usage:
 #   ./missing-testdata.sh </path/to/SAMPLE_DIR>
@@ -8,6 +8,9 @@
 set -e -u -o pipefail
 SAMPLE_DIR=${1:-"$(dirname $0)/../../malcontent-samples"}
 
+# number of days to look back for missing testdata
+AGE_IN_DAYS=30
+
 SAMPLE_DIR=$(realpath ${SAMPLE_DIR})
 
 if [[ ! -d "${SAMPLE_DIR}/does-nothing" ]]; then
@@ -15,7 +18,7 @@ if [[ ! -d "${SAMPLE_DIR}/does-nothing" ]]; then
 	exit 1
 fi
 
-for sample_path in $(find "${SAMPLE_DIR}/" -type f -size +100c); do
+for sample_path in $(find "${SAMPLE_DIR}/" -type f -mtime -"${AGE_IN_DAYS}" -size +100c); do
 	if [[ "${sample_path}" =~ ".git" ]]; then
 		continue
 	fi


### PR DESCRIPTION
I use this when I add new samples. script emits the commands you need to add initial empty testdata for the refresh stage to fill.