### PR TITLE
Update relative path check when extracting tar archives

### DIFF
--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -150,8 +150,8 @@ func extractTar(ctx context.Context, d string, f string) error {
 		}
 
 		clean := filepath.Clean(header.Name)
-		if filepath.IsAbs(clean) || strings.Contains(clean, "..") {
-			return fmt.Errorf("invalid file path: %s", header.Name)
+		if filepath.IsAbs(clean) || strings.Contains(clean, "../") {
+			return fmt.Errorf("path is absolute or contains a relative path traversal: %s", clean)
 		}
 
 		target := filepath.Join(d, clean)


### PR DESCRIPTION
We encountered failures when scanning certain archives with truncated names:
```
🔎 Scanning "packages-x86_64/packages/x86_64/trino-plugin-mysql-464-r3.apk"
time=2024-11-22T14:33:46.280-08:00 level=ERROR source=.../go/pkg/mod/github.com/chainguard-dev/malcontent@v1.5.1/pkg/action/scan.go:325 msg="unable to process packages-x86_64/packages/x86_64/trino-plugin-mysql-464-r3.apk: extract to temp: failed to extract packages-x86_64/packages/x86_64/trino-plugin-mysql-464-r3.apk: invalid file path: usr/lib/trino/lib/com.faster...on.module_jackson-module-parameter-names-2.18.1.jar"
```

These files are truncated even when extracted outside of Go, so it's likely this happened as part of the archive creation:
```
ls -l usr/lib/trino/lib/ | awk '{ print $8 }' | grep '\.\.\.'
com.faster...on.module_jackson-module-parameter-names-2.18.1.jar
com.fasterxml...kson.datatype_jackson-datatype-jsr310-2.18.1.jar
io.ope...mconv_opentelemetry-semconv-incubating-1.28.0-alpha.jar
io.opent...entation_opentelemetry-instrumentation-api-2.10.0.jar
io.openteleme...trumentation_opentelemetry-jdbc-2.10.0-alpha.jar
```

The reason the scans were failing was because we were checking for `..` in the filepath when extracting archives rather than `../` and the latter should suffice when determining relative path traversals. 

While it would be nice to have the untruncated file names, this fix allows the scans to succeed:
```
$ go run cmd/mal/mal.go --format simple analyze ~/Downloads/packages-x86_64\(2\)/packages/x86_64/trino-plugin-mysql-465-r0.apk
# ~/Downloads/packages-x86_64(2)/packages/x86_64/trino-plugin-mysql-465-r0.apk ∴ /var/lib/db/sbom/trino-plugin-mysql-465-r0.spdx.json: medium
collect/databases/mysql: medium
exec/plugin: low
net/download: medium
net/url/embedded: low
```

