### PR TITLE
include full warning in warning log

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -193,7 +193,7 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 		if !known {
 			logger.With("namespace, r.Namespace(), "id", id).Errorf("disabled due to unexpected warning: %s", warnings[id])
 		} else {
-			logger.With("namespace, r.Namespace(), "id", id).Infof("disabled due to unexpected warning: %s", warnings[id])
+			logger.With("namespace, r.Namespace(), "id", id).Infof("disabled due to expected warning: %s", warnings[id])
 		}
 		r.Disable()
 	}

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"path/filepath"
 	"strings"
 

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -191,9 +191,9 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 			continue
 		}
 		if !known {
-			logger.With("namespace, r.Namespace(), "id", id).Errorf("disabled due to unexpected warning: %s", warnings[id])
+			logger.With("namespace", r.Namespace(), "id", id).Errorf("disabled due to unexpected warning: %s", warnings[id])
 		} else {
-			logger.With("namespace, r.Namespace(), "id", id).Infof("disabled due to expected warning: %s", warnings[id])
+			logger.With("namespace", r.Namespace(), "id", id).Infof("disabled due to expected warning: %s", warnings[id])
 		}
 		r.Disable()
 	}

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -148,7 +148,7 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 
 	warnings := map[string]string{}
 	for _, ycw := range yc.Warnings {
-		clog.WarnContext(ctx, "warning", slog.String("filename", ycw.Filename), slog.Int("line", ycw.Line), slog.String("text", ycw.Text))
+		clog.WarnContextf(ctx, "warning in %s line %d: %s", ycw.Filename, ycw.Line, ycw.Text)
 		if ycw.Rule == "" {
 			continue
 		}


### PR DESCRIPTION
Using malcontent as a library on GCP with [`clog/gcp`](https://github.com/chainguard-dev/clog/tree/4c523ae4593f9840ecebc4a182e6aa7c02b5be32/gcp) results in less-than-useful log messages:

<img width="644" alt="Screenshot 2024-12-10 at 10 30 42 AM" src="https://github.com/user-attachments/assets/1dbd4b3b-2bc2-40f7-98c9-2c6d6e9efcfe">

The information is still available, but it requires clicking through.

I don't think this should have a significant impact on the behavior of these logs in the CLI, it'll just be a "normal" log line instead of something like `warning filename=foo line=123 text=string may be slow`