### PR TITLE
Demote additional logs from Info to Debug

### DIFF
--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -81,7 +81,7 @@ const maxBytes = 1 << 29 // 512MB
 // extractTar extracts .apk and .tar* archives.
 func extractTar(ctx context.Context, d string, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
-	logger.Info("extracting tar")
+	logger.Debug("extracting tar")
 
 	// Check if the file is valid
 	_, err := os.Stat(f)
@@ -203,7 +203,7 @@ func extractTar(ctx context.Context, d string, f string) error {
 // extractGzip extracts .gz archives.
 func extractGzip(ctx context.Context, d string, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
-	logger.Info("extracting gzip")
+	logger.Debug("extracting gzip")
 
 	// Check if the file is valid
 	_, err := os.Stat(f)
@@ -242,7 +242,7 @@ func extractGzip(ctx context.Context, d string, f string) error {
 // extractZip extracts .jar and .zip archives.
 func extractZip(ctx context.Context, d string, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
-	logger.Info("extracting zip")
+	logger.Debug("extracting zip")
 
 	// Check if the file is valid
 	_, err := os.Stat(f)
@@ -316,7 +316,7 @@ func extractZip(ctx context.Context, d string, f string) error {
 // extractRPM extracts .rpm packages.
 func extractRPM(ctx context.Context, d, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
-	logger.Info("extracting rpm")
+	logger.Debug("extracting rpm")
 
 	rpmFile, err := os.Open(f)
 	if err != nil {
@@ -409,7 +409,7 @@ func extractRPM(ctx context.Context, d, f string) error {
 // extractDeb extracts .deb packages.
 func extractDeb(ctx context.Context, d, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
-	logger.Info("extracting deb")
+	logger.Debug("extracting deb")
 
 	fd, err := os.Open(f)
 	if err != nil {
@@ -530,7 +530,7 @@ func extractNestedArchive(
 // extractArchiveToTempDir creates a temporary directory and extracts the archive file for scanning.
 func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 	logger := clog.FromContext(ctx).With("path", path)
-	logger.Info("creating temp dir")
+	logger.Debug("creating temp dir")
 
 	tmpDir, err := os.MkdirTemp("", filepath.Base(path))
 	if err != nil {

--- a/pkg/action/oci.go
+++ b/pkg/action/oci.go
@@ -14,7 +14,7 @@ import (
 
 func prepareImage(ctx context.Context, d string) (string, *os.File, error) {
 	logger := clog.FromContext(ctx).With("image", d)
-	logger.Info("preparing image")
+	logger.Debug("preparing image")
 	tmpDir, err := os.MkdirTemp("", filepath.Base(d))
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create temp dir: %w", err)

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -46,7 +46,7 @@ func findFilesRecursively(ctx context.Context, rootPath string) ([]string, error
 		// If the target does not exist, log the error but return gracefully
 		// This is useful when scanning -compat packages
 		if os.IsNotExist(err) {
-			logger.Infof("symlink target does not exist: %s", err.Error())
+			logger.Debugf("symlink target does not exist: %s", err.Error())
 			return nil, nil
 		}
 		// Allow /proc/XXX/exe to be scanned even if symlink is not resolveable
@@ -135,7 +135,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 		yrs = c.Rules
 	}
 	if err := yrs.ScanFileDescriptor(fd, 0, 0, &mrs); err != nil {
-		logger.Info("skipping", slog.Any("error", err))
+		logger.Debug("skipping", slog.Any("error", err))
 		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("scan: %v", err)}, nil
 	}
 
@@ -537,7 +537,7 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 	}
 
 	if fr == nil {
-		logger.Infof("%s returned nil result", path)
+		logger.Debugf("%s returned nil result", path)
 		return nil, nil
 	}
 


### PR DESCRIPTION
We've had a chance to test most of these code paths, so having the logs emitting as info causes noise, especially when running malcontent via Cloud Run and logging the output.

Running `--verbose` will always show these logs if they ever need to be referenced.

h/t to @imjasonh for pointing this out.