### PR TITLE
Add support for zstd RPM files

### DIFF
--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cavaliergopher/cpio"
 	"github.com/cavaliergopher/rpm"
 	"github.com/chainguard-dev/clog"
+	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 )
 
@@ -60,6 +61,12 @@ func ExtractRPM(ctx context.Context, d, f string) error {
 			return fmt.Errorf("failed to create xz reader: %w", err)
 		}
 		cr = cpio.NewReader(xzStream)
+	case "zstd":
+		zstdStream, err := zstd.NewReader(rpmFile)
+		if err != nil {
+			return fmt.Errorf("failed to create zstd reader: %w", err)
+		}
+		cr = cpio.NewReader(zstdStream)
 	default:
 		return fmt.Errorf("unsupported compression format: %s", compression)
 	}


### PR DESCRIPTION
I noticed that we weren't extracting `zstd` RPM files:
```
unable to process /tmp/malcontent-3727400076/srv/gitlab/vendor/bundle/ruby/3.2.0/gems/arr-pm-0.0.12/spec/fixtures/pagure-mirror-5.13.2-5.fc35.noarch.rpm: extract to temp: failed to extract /tmp/malcontent-3727400076/srv/gitlab/vendor/bundle/ruby/3.2.0/gems/arr-pm-0.0.12/spec/fixtures/pagure-mirror-5.13.2-5.fc35.noarch.rpm: unsupported compression format: zstd
```

This PR adds another case statement to allow for these files to be extracted:
```
🔎 Scanning "~/Downloads/gitlab-rails/srv/gitlab/vendor/bundle/ruby/3.2.0/gems/arr-pm-0.0.12/spec/fixtures/pagure-mirror-5.13.2-5.fc35.noarch.rpm"
Matches for ~/Downloads/gitlab-rails/srv/gitlab/vendor/bundle/ruby/3.2.0/gems/arr-pm-0.0.12/spec/fixtures/pagure-mirror-5.13.2-5.fc35.noarch.rpm ∴ /usr/lib/systemd/system/pagure_mirror.service [LOW] (4 rules):
etc_path [LOW] (1 string):
- /etc/pagure/pagure.cfg
https_url [LOW] (1 string):
- https://pagure.io/pagure
ref_systemd [LOW] (1 string):
- systemd
usr_bin_path [LOW] (1 string):
- /usr/bin/celery-3
```