### PR TITLE
Add perl to third-party Workflow

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add bash curl findutils gh git go nodejs upx xz yara-x-compat
+          apk add bash curl findutils gh git go nodejs perl upx xz yara-x-compat
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
       - name: Set up Octo-STS


### PR DESCRIPTION
Quick follow-up for #734. Now that we're using a Wolfi container, we need to install perl separately so that `update.sh` can run.

I verified this fix by installing all of the required packages in a `wolfi-base` container followed by running `make update-third-party`