### PR TITLE
Trust `$GITHUB_WORKSPACE`  in third-party Workflow

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Trust repository
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Unit tests
         run: |
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Trust repository
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Integration tests
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Trust repository
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run golangci-lint
         run: |

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -36,6 +36,8 @@ jobs:
           apk update
           apk add bash curl findutils gh git go nodejs perl upx xz yara-x-compat
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Trust repository
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
       - name: Set up Octo-STS
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -37,7 +37,7 @@ jobs:
           apk add bash curl findutils gh git go nodejs perl upx xz yara-x-compat
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Trust repository
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
       - name: Set up Octo-STS
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0


### PR DESCRIPTION
Like the other container-based jobs, we need to trust the `$GITHUB_WORKSPACE` (fun aside: `$GITHUB_WORKSPACE` is not the same as `${{ github.workspace }}` when using a container) in the third-party update job (since containers operate differently from VMs).