### PR TITLE
Specify bash for PR creation; quote more strings

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -59,10 +59,11 @@ jobs:
           if [[ -n $(git status -s) ]]; then
             DATE=$(date +%F)
             BRANCH="third-party-rule-update-${DATE}"
-            git checkout -b $BRANCH
+            git checkout -b "$BRANCH"
             git add .
             git commit -m "Update third-party rules as of ${DATE}"
-            git push origin $BRANCH
+            git push origin "$BRANCH"
 
             gh pr create -t "Update third-party rules as of ${DATE}" -b "${DATE} third-party rule update for malcontent." -B main
           fi
+        shell: bash

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -75,10 +75,10 @@ jobs:
         sed -i "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"${VERSION}\"/" ${{ env.VERSION_FILE }}
 
         BRANCH="malcontent-version-bump-$VERSION"
-        git checkout -b $BRANCH
+        git checkout -b "$BRANCH"
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump malcontent version to $VERSION"
-        git push origin $BRANCH
+        git push origin "$BRANCH"
 
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Create Pull Request


### PR DESCRIPTION
Even though we've installed Bash in the job container, GitHub seems to be using `sh`:
```
sh: third_party/yara/YARAForge/RELEASE: unknown operand
```

This PR explicitly tells the PR creation step to run via `bash` when we create the third-party update PR so that the `[[` test will succeed.

I also went through and quoted remaining string variables for consistency.