### PR TITLE
Specify -H for PR creations

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -64,6 +64,6 @@ jobs:
             git commit -m "Update third-party rules as of ${DATE}"
             git push origin "$BRANCH"
 
-            gh pr create -t "Update third-party rules as of ${DATE}" -b "${DATE} third-party rule update for malcontent." -B main
+            gh pr create -t "Update third-party rules as of ${DATE}" -b "${DATE} third-party rule update for malcontent." -B main -H "$BRANCH"
           fi
         shell: bash

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -80,8 +80,8 @@ jobs:
         git commit -m "Bump malcontent version to $VERSION"
         git push origin "$BRANCH"
         
-        echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "BRANCH=$BRANCH" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -79,11 +79,13 @@ jobs:
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump malcontent version to $VERSION"
         git push origin "$BRANCH"
-
+        
+        echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       run: |
+        BRANCH=${{ steps.update.outputs.BRANCH }}
         VERSION=${{ steps.update.outputs.VERSION }}
-        gh pr create -t "Update malcontent to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main
+        gh pr create -t "Update malcontent to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main -H "$BRANCH"


### PR DESCRIPTION
Creating PRs (e.g., to bump the version) has started failing with this error:
```
 aborted: you must first push the current branch to a remote, or use the --head flag
```

Though we're definitely pushing to the remote branch:
```
Current malcontent version: v1.7.1
New malcontent version: v1.8.0
Switched to a new branch 'malcontent-version-bump-v1.8.0'
[malcontent-version-bump-v1.8.0 4fd1b97] Bump malcontent version to v1.8.0
 1 file changed, 1 insertion(+), 1 deletion(-)
remote: 
remote: Create a pull request for 'malcontent-version-bump-v1.8.0' on GitHub by visiting:        
remote:      https://github.com/chainguard-dev/malcontent/pull/new/malcontent-version-bump-v1.8.0        
remote: 
To https://github.com/chainguard-dev/malcontent
 * [new branch]      malcontent-version-bump-v1.8.0 -> malcontent-version-bump-v1.8.0
```

This failure is odd given that this hasn't been an issue until just recently. 

I ran into this in another repository yesterday and specifying the head branch resolved the issue so hopefully it works here as well.