### PR TITLE
Allow for number of scanners to be configurable

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -57,7 +57,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 
 	var pool *malcontent.ScannerPool
 	if c.ScannerPool == nil {
-		pool, err = malcontent.NewScannerPool(yrs, c.Concurrency)
+		pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create scanner pool: %w", err)
 		}

--- a/pkg/refresh/action.go
+++ b/pkg/refresh/action.go
@@ -69,6 +69,7 @@ func actionRefresh(ctx context.Context) ([]TestData, error) {
 		c := &malcontent.Config{
 			Concurrency:           runtime.NumCPU(),
 			IgnoreSelf:            false,
+			MaxScanners:           runtime.NumCPU(),
 			MinFileRisk:           0,
 			MinRisk:               0,
 			OCI:                   false,
@@ -81,7 +82,7 @@ func actionRefresh(ctx context.Context) ([]TestData, error) {
 
 		var pool *malcontent.ScannerPool
 		if c.ScannerPool == nil {
-			pool, err = malcontent.NewScannerPool(yrs, c.Concurrency)
+			pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/refresh/diff.go
+++ b/pkg/refresh/diff.go
@@ -196,6 +196,7 @@ func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 			Concurrency:           runtime.NumCPU(),
 			FileRiskChange:        td.riskChange,
 			FileRiskIncrease:      td.riskIncrease,
+			MaxScanners:           runtime.NumCPU(),
 			MinFileRisk:           minFileRisk,
 			MinRisk:               minRisk,
 			QuantityIncreasesRisk: true,
@@ -207,7 +208,7 @@ func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 
 		var pool *malcontent.ScannerPool
 		if c.ScannerPool == nil {
-			pool, err = malcontent.NewScannerPool(yrs, c.Concurrency)
+			pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -74,6 +74,7 @@ func newConfig(rc Config) *malcontent.Config {
 	return &malcontent.Config{
 		Concurrency:           runtime.NumCPU(),
 		IgnoreTags:            []string{"harmless"},
+		MaxScanners:           runtime.NumCPU(),
 		MinFileRisk:           1,
 		MinRisk:               1,
 		QuantityIncreasesRisk: true,


### PR DESCRIPTION
Follow-up for #760 -- turns out, yara-x is trying to reserve a large amount of memory for each scanner it creates which causes issues in Cloud Run.

To avoid this, we can make the number of scanners configurable (similar to overall concurrency).

I tested this and the performance difference between one scanner and the default of `runtime.NumCPU` is about 7x for very large packages (number of files), so hopefully we can at least run 2-4 in Cloud Run. That said, we can always sacrifice performance for stability and most scans are in the tens of files, not hundreds of thousands.

To set the new value, we'll just add `MaxScanners: <value>` to the config where necessary (similar to the changes in the refresh code in this PR).