### PR TITLE
chore: remove `go` version in golangci config in favor of go version in go.mod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 run:
   # The default runtime timeout is 1m, which doesn't work well on Github Actions.
   timeout: 10m
-  go: "1.23"
 
 # NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
 linters-settings:


### PR DESCRIPTION
if not specifying the go version, it would fallback to the version in go.mod, I think that that would be better to keep the go version consistency. 