### PR TITLE
Remove scanner pool in favor of single-use scanners

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -63,7 +63,6 @@ var (
 	outputFlag                string
 	profileFlag               bool
 	quantityIncreasesRiskFlag bool
-	scannersFlag              int
 	statsFlag                 bool
 	thirdPartyFlag            bool
 	verboseFlag               bool
@@ -250,11 +249,6 @@ func main() {
 				concurrency = 1
 			}
 
-			maxScanners := scannersFlag
-			if maxScanners > concurrency {
-				maxScanners = concurrency
-			}
-
 			mc = malcontent.Config{
 				Concurrency:           concurrency,
 				ExitFirstHit:          exitFirstHitFlag,
@@ -368,12 +362,6 @@ func main() {
 				Value:       true,
 				Usage:       "Increase file risk score based on behavior quantity",
 				Destination: &quantityIncreasesRiskFlag,
-			},
-			&cli.IntFlag{
-				Name:        "scanners",
-				Value:       runtime.NumCPU(),
-				Usage:       "Number of scanners to create",
-				Destination: &scannersFlag,
 			},
 			&cli.BoolFlag{
 				Name:        "stats",

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -255,14 +255,6 @@ func main() {
 				maxScanners = concurrency
 			}
 
-			var pool *malcontent.ScannerPool
-			if mc.ScannerPool == nil {
-				pool, err = malcontent.NewScannerPool(yrs, maxScanners)
-				if err != nil {
-					returnCode = ExitInvalidRules
-				}
-			}
-
 			mc = malcontent.Config{
 				Concurrency:           concurrency,
 				ExitFirstHit:          exitFirstHitFlag,
@@ -270,7 +262,6 @@ func main() {
 				IgnoreSelf:            ignoreSelfFlag,
 				IgnoreTags:            ignoreTags,
 				IncludeDataFiles:      includeDataFiles,
-				MaxScanners:           maxScanners,
 				MinFileRisk:           minFileRisk,
 				MinRisk:               minRisk,
 				OCI:                   ociFlag,
@@ -278,7 +269,6 @@ func main() {
 				Renderer:              renderer,
 				Rules:                 yrs,
 				ScanPaths:             scanPaths,
-				ScannerPool:           pool,
 				Stats:                 statsFlag,
 			}
 

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -55,22 +55,6 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 		yrs = c.Rules
 	}
 
-	var pool *malcontent.ScannerPool
-	if c.ScannerPool == nil {
-		pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create scanner pool: %w", err)
-		}
-		c.ScannerPool = pool
-	}
-
-	var scanner *yarax.Scanner
-	scanner, err = c.ScannerPool.Get()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve scanner: %w", err)
-	}
-	defer c.ScannerPool.Put(scanner)
-
 	isArchive := archiveRoot != ""
 	mime := "<unknown>"
 	kind, err := programkind.File(path)
@@ -91,7 +75,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 		return nil, err
 	}
 
-	mrs, err := scanner.Scan(fc)
+	mrs, err := yrs.Scan(fc)
 	if err != nil {
 		logger.Debug("skipping", slog.Any("error", err))
 		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("scan: %v", err)}, nil

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -5,12 +5,9 @@ package malcontent
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
-	"runtime"
 	"sync"
-	"sync/atomic"
 
 	yarax "github.com/VirusTotal/yara-x/go"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
@@ -33,7 +30,6 @@ type Config struct {
 	IgnoreSelf            bool
 	IgnoreTags            []string
 	IncludeDataFiles      bool
-	MaxScanners           int
 	MinFileRisk           int
 	MinRisk               int
 	OCI                   bool
@@ -45,7 +41,6 @@ type Config struct {
 	Rules                 *yarax.Rules
 	Scan                  bool
 	ScanPaths             []string
-	ScannerPool           *ScannerPool
 	Stats                 bool
 	TrimPrefixes          []string
 }
@@ -147,143 +142,4 @@ type CombinedReport struct {
 	Removed   string
 	RemovedFR *FileReport
 	Score     float64
-}
-
-// ScannerPool manages a limited pool of YARA scanners.
-type ScannerPool struct {
-	mu           sync.Mutex
-	rules        *yarax.Rules
-	scanners     []*yarax.Scanner
-	available    chan *yarax.Scanner
-	maxScanners  int32
-	currentCount int32
-	closed       atomic.Bool
-}
-
-// NewScannerPool creates a new scanner pool with a maximum number of scanners.
-func NewScannerPool(rules *yarax.Rules, maxScanners int) (*ScannerPool, error) {
-	if rules == nil {
-		return nil, fmt.Errorf("rules cannot be nil")
-	}
-	if maxScanners < 1 {
-		maxScanners = max(1, runtime.GOMAXPROCS(0)/2)
-	}
-
-	// #nosec G115 // ignore converting int to int32
-	pool := &ScannerPool{
-		rules:       rules,
-		available:   make(chan *yarax.Scanner, maxScanners),
-		maxScanners: int32(maxScanners),
-		scanners:    make([]*yarax.Scanner, 0, maxScanners),
-		closed:      atomic.Bool{},
-	}
-
-	scanner := yarax.NewScanner(rules)
-	if scanner == nil {
-		return nil, fmt.Errorf("failed to create scanner")
-	}
-
-	pool.available <- scanner
-	atomic.AddInt32(&pool.currentCount, 1)
-
-	return pool, nil
-}
-
-// createScanner creates a new yarax scanner.
-func (p *ScannerPool) createScanner() (*yarax.Scanner, error) {
-	if atomic.LoadInt32(&p.currentCount) > p.maxScanners/2 {
-		runtime.GC()
-	}
-
-	if p.rules == nil {
-		return nil, fmt.Errorf("rules not initialized")
-	}
-
-	scanner := yarax.NewScanner(p.rules)
-	if scanner == nil {
-		return nil, fmt.Errorf("failed to create new scanner")
-	}
-
-	if err := p.validateScanner(scanner); err != nil {
-		scanner.Destroy()
-		return nil, err
-	}
-
-	return scanner, nil
-}
-
-// validateScanner attempts to compile the provided rules.
-func (p *ScannerPool) validateScanner(scanner *yarax.Scanner) error {
-	if scanner == nil {
-		return fmt.Errorf("nil scanner")
-	}
-	_, err := scanner.Scan([]byte("test"))
-	if err != nil {
-		return fmt.Errorf("scanner validation failed: %w", err)
-	}
-	return nil
-}
-
-// Get retrieves a scanner from the pool or creates a new one if necessary.
-func (p *ScannerPool) Get() (*yarax.Scanner, error) {
-	if p.closed.Load() {
-		return nil, fmt.Errorf("scanner pool is closed")
-	}
-
-	// Retrieve an existing scanner
-	// If none are available, create up to the maximum number of scanners
-	select {
-	case scanner := <-p.available:
-		return scanner, nil
-	default:
-		p.mu.Lock()
-		if atomic.LoadInt32(&p.currentCount) < p.maxScanners {
-			scanner, err := p.createScanner()
-			if err != nil {
-				p.mu.Unlock()
-				return nil, fmt.Errorf("create scanner: %w", err)
-			}
-			p.scanners = append(p.scanners, scanner)
-			atomic.AddInt32(&p.currentCount, 1)
-			p.mu.Unlock()
-			return scanner, nil
-		}
-		p.mu.Unlock()
-
-		return <-p.available, nil
-	}
-}
-
-// Put returns a scanner to the pool.
-func (p *ScannerPool) Put(scanner *yarax.Scanner) {
-	if scanner == nil || p.closed.Load() {
-		return
-	}
-	p.available <- scanner
-}
-
-// Cleanup destroys all scanners in the pool.
-func (p *ScannerPool) Cleanup() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.closed.Swap(true) {
-		return
-	}
-
-	for len(p.available) > 0 {
-		if scanner := <-p.available; scanner != nil {
-			scanner.Destroy()
-		}
-	}
-	close(p.available)
-
-	for _, scanner := range p.scanners {
-		if scanner != nil {
-			scanner.Destroy()
-		}
-	}
-
-	p.scanners = nil
-	atomic.StoreInt32(&p.currentCount, 0)
 }

--- a/pkg/refresh/action.go
+++ b/pkg/refresh/action.go
@@ -69,7 +69,6 @@ func actionRefresh(ctx context.Context) ([]TestData, error) {
 		c := &malcontent.Config{
 			Concurrency:           runtime.NumCPU(),
 			IgnoreSelf:            false,
-			MaxScanners:           runtime.NumCPU(),
 			MinFileRisk:           0,
 			MinRisk:               0,
 			OCI:                   false,
@@ -78,15 +77,6 @@ func actionRefresh(ctx context.Context) ([]TestData, error) {
 			Rules:                 yrs,
 			ScanPaths:             []string{scan},
 			TrimPrefixes:          []string{"pkg/action/"},
-		}
-
-		var pool *malcontent.ScannerPool
-		if c.ScannerPool == nil {
-			pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
-			if err != nil {
-				return nil, err
-			}
-			c.ScannerPool = pool
 		}
 
 		testData = append(testData, TestData{

--- a/pkg/refresh/diff.go
+++ b/pkg/refresh/diff.go
@@ -196,7 +196,6 @@ func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 			Concurrency:           runtime.NumCPU(),
 			FileRiskChange:        td.riskChange,
 			FileRiskIncrease:      td.riskIncrease,
-			MaxScanners:           runtime.NumCPU(),
 			MinFileRisk:           minFileRisk,
 			MinRisk:               minRisk,
 			QuantityIncreasesRisk: true,
@@ -204,15 +203,6 @@ func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 			Rules:                 yrs,
 			ScanPaths:             []string{src, dest},
 			TrimPrefixes:          []string{rc.SamplesPath},
-		}
-
-		var pool *malcontent.ScannerPool
-		if c.ScannerPool == nil {
-			pool, err = malcontent.NewScannerPool(yrs, c.MaxScanners)
-			if err != nil {
-				return nil, err
-			}
-			c.ScannerPool = pool
 		}
 
 		testData = append(testData, TestData{


### PR DESCRIPTION
The scanner pool concept was neat in theory, but yara-x leverages WASM which exhibits unpredictable behavior when a new scanner is created. Notably, each new scanner is allocated 8GB of virtual memory for the time being and this value is not configurable. Controlling this behavior with a separate value then adds another layer of complexity.

This PR reverts to the original pattern we used for go-yara with the main downside being that we are unable to scan file descriptors with yara-x and must instead read the entire file into memory before scanning it. That said, we'll be able to directly influence how many scanners are created with `c.Concurrency` rather than needing to account for two values. Ultimately, not using the scanner pool has little impact on performance (though I'd much rather have stability right now anyway).

To allow for yara-x to work in environments like Cloud Run, we'll still need a change that allows for WASM tuning to drop the memory reservation to hopefully free up virtual memory overhead and prevent panics.