### PR TITLE
Optimize memory usage in report.go and scan.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ LINTERS :=
 FIXERS :=
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v1.63.4
 GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters
@@ -174,7 +174,7 @@ refresh-sample-testdata: out/$(SAMPLES_REPO)/.decompressed-$(SAMPLES_COMMIT) out
 	./out/mal refresh
 
 ARCH ?= $(shell uname -m)
-CRANE_VERSION=v0.20.2
+CRANE_VERSION=v0.20.3
 out/crane-$(ARCH)-$(CRANE_VERSION):
 	mkdir -p out
 	GOBIN=$(CURDIR)/out go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -75,7 +75,6 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
@@ -89,6 +88,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	if err != nil {
 		return nil, err
 	}
+	f.Close()
 
 	mrs, err := yrs.Scan(fc)
 	if err != nil {
@@ -100,7 +100,11 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	if err != nil {
 		return nil, err
 	}
-	f.Close()
+
+	if fr.Error != "" {
+		logger.Debug("skipping", slog.Any("error", err))
+		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("generate: %v", fr.Error)}, nil
+	}
 
 	// Clean up the path if scanning an archive
 	var clean string

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -75,6 +75,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
@@ -84,11 +85,9 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	size := fi.Size()
 	fc := make([]byte, size)
 
-	_, err = io.ReadFull(f, fc)
-	if err != nil {
+	if _, err := io.ReadFull(f, fc); err != nil {
 		return nil, err
 	}
-	f.Close()
 
 	mrs, err := yrs.Scan(fc)
 	if err != nil {

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -102,7 +102,6 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	}
 
 	if fr.Error != "" {
-		logger.Debug("skipping", slog.Any("error", err))
 		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("generate: %v", fr.Error)}, nil
 	}
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -367,7 +367,7 @@ func TrimPrefixes(path string, prefixes []string) string {
 //nolint:cyclop // ignore complexity of 64
 func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte) (*malcontent.FileReport, error) {
 	if mrs == nil {
-		return nil, fmt.Errorf("yara-x scan results are nil for %s", path)
+		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("yara-x scan results are nil for %s", path)}, nil
 	}
 
 	ignoreTags := c.IgnoreTags

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -366,6 +366,10 @@ func TrimPrefixes(path string, prefixes []string) string {
 
 //nolint:cyclop // ignore complexity of 64
 func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte) (*malcontent.FileReport, error) {
+	if mrs == nil {
+		return nil, fmt.Errorf("yara-x scan results are nil for %s", path)
+	}
+
 	ignoreTags := c.IgnoreTags
 	minScore := c.MinRisk
 	ignoreSelf := c.IgnoreSelf


### PR DESCRIPTION
This PR leverages the profiling changes from #767 and reduces the memory usage of Malcontent by 1-3GB when scanning many files by using `io.ReadFull` when reading file contents, closing the file immediately after processing, and allowing match strings and the string processor to be GC'd earlier in `report.go`.

Other than that, I made some small safety tweeks re: `mrs` in `Generate`.

I ran these changes several times with `make refresh-sample-testdata` which is a worst case scenario and usage topped out at ~7-8GB instead of 10+. Now that we're using yara-x, we want to work on minimizing our memory footprint as much as possible (although yara-x just shipped a PR to help with virtual address space usage which should be included in the next release).