### PR TITLE
scan: Fix panic if renderer is not set.

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -576,7 +576,7 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 // Scan YARA scans a data source, applying output filters if necessary.
 func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
 	r, err := recursiveScan(ctx, c)
-	if err != nil && c.Renderer.Name() != interactive {
+	if err != nil && (c.Renderer == nil || c.Renderer.Name() != interactive) {
 		return r, err
 	}
 	r.Files.Range(func(key, value any) bool {


### PR DESCRIPTION
We're seeing a panic while running this in presubmit:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xd8bc85]

goroutine 1148350 [running]:
github.com/chainguard-dev/malcontent/pkg/action.Scan({0x2c8cc68?, 0xc00aa5e510?}, {0x8, 0x0, 0x0, 0x0, 0x0, 0x1, {0x0, 0x0, ...}, ...})
	github.com/chainguard-dev/malcontent@v1.8.3/pkg/action/scan.go:579 +0x85
```

Likely cause is if `Name()` is called if `c.Renderer` is not set.