### PR TITLE
Remove FileReport Error field in favor of custom error type

### DIFF
--- a/pkg/action/diff.go
+++ b/pkg/action/diff.go
@@ -96,7 +96,7 @@ func relFileReport(ctx context.Context, c malcontent.Config, fromPath string) (m
 		}
 		if fr, ok := value.(*malcontent.FileReport); ok {
 			isArchive := fr.ArchiveRoot != ""
-			if fr.Skipped != "" || fr.Error != "" {
+			if fr.Skipped != "" {
 				return true
 			}
 			rel, base, err = relPath(fromPath, fr, isArchive)

--- a/pkg/action/scan_error.go
+++ b/pkg/action/scan_error.go
@@ -69,8 +69,6 @@ func (e *FileReportError) Is(target error) bool {
 
 func (e *FileReportError) Path() string { return e.path }
 
-func (e *FileReportError) Reason() string { return e.Error() }
-
 func (e *FileReportError) Type() ErrorType {
 	return e.reason
 }

--- a/pkg/action/scan_error.go
+++ b/pkg/action/scan_error.go
@@ -14,12 +14,12 @@ const (
 type ErrorType int
 
 // Error type iotas.
-// TypeUnknown will be the default of `0`.
-// TypeScanError is to be used when compiled rules are invalid or the scan fails otherwise.
-// TypeGenerateError is to be used when a file's report cannot be created.
 const (
+	// TypeUnknown will be the default of `0`.
 	TypeUnknown ErrorType = iota
+	// TypeScanError is to be used when compiled rules are invalid or the scan fails otherwise.
 	TypeScanError
+	// TypeGenerateError is to be used when a file's report cannot be created.
 	TypeGenerateError
 )
 

--- a/pkg/action/scan_error.go
+++ b/pkg/action/scan_error.go
@@ -1,0 +1,67 @@
+package action
+
+import "fmt"
+
+const (
+	errMsgScanFailed     = "scan failed"
+	errMsgGenerateFailed = "failed to generate file report"
+	errMsgNilReport      = "file report is nil"
+)
+
+type ErrorType int
+
+const (
+	TypeScanError ErrorType = iota
+	TypeGenerateError
+	TypeNilError
+)
+
+type FileReportError struct {
+	err    error
+	path   string
+	reason string
+}
+
+func NewFileReportError(err error, path, reason string) *FileReportError {
+	return &FileReportError{
+		err:    err,
+		path:   path,
+		reason: reason,
+	}
+}
+
+func (e *FileReportError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.reason, e.path, e.err)
+	}
+	return fmt.Sprintf("%s: %s", e.reason, e.path)
+}
+
+func (e *FileReportError) Is(target error) bool {
+	t, ok := target.(*FileReportError)
+	if !ok {
+		return false
+	}
+	return e.path == t.path && e.reason == t.reason
+}
+
+func (e *FileReportError) Path() string { return e.path }
+
+func (e *FileReportError) Reason() string { return e.reason }
+
+func (e *FileReportError) Type() ErrorType {
+	switch e.reason {
+	case errMsgScanFailed:
+		return TypeScanError
+	case errMsgGenerateFailed:
+		return TypeGenerateError
+	case errMsgNilReport:
+		return TypeNilError
+	default:
+		return -1
+	}
+}
+
+func (e *FileReportError) Unwrap() error {
+	return e.err
+}

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -79,7 +79,6 @@ type FileReport struct {
 	SHA256 string
 	Size   int64
 	// compiler -> x
-	Error             string            `json:",omitempty" yaml:",omitempty"`
 	Skipped           string            `json:",omitempty" yaml:",omitempty"`
 	Meta              map[string]string `json:",omitempty" yaml:",omitempty"`
 	Syscalls          []string          `json:",omitempty" yaml:",omitempty"`

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -154,12 +154,6 @@ func (r Markdown) Full(ctx context.Context, _ *malcontent.Config, rep *malconten
 }
 
 func markdownTable(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
-	path := fr.Path
-	if fr.Error != "" {
-		fmt.Printf("⚠️ %s - error: %s\n", path, fr.Error)
-		return
-	}
-
 	if fr.Skipped != "" {
 		return
 	}

--- a/pkg/render/tea.go
+++ b/pkg/render/tea.go
@@ -363,8 +363,6 @@ func (r *Interactive) File(ctx context.Context, fr *malcontent.FileReport) error
 
 	var content string
 	switch {
-	case fr.Error != "":
-		content = fmt.Sprintf("error scanning %s: %s", fr.Path, fr.Error)
 	case fr.Skipped != "":
 		content = fmt.Sprintf("skipped %s: %s", fr.Path, fr.Skipped)
 	case len(fr.Behaviors) > 0:

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -367,7 +367,7 @@ func TrimPrefixes(path string, prefixes []string) string {
 //nolint:cyclop // ignore complexity of 64
 func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte) (*malcontent.FileReport, error) {
 	if mrs == nil {
-		return nil, fmt.Errorf("yara-x scan results are nil")
+		return nil, fmt.Errorf("scan failed")
 	}
 
 	ignoreTags := c.IgnoreTags

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -367,7 +367,7 @@ func TrimPrefixes(path string, prefixes []string) string {
 //nolint:cyclop // ignore complexity of 64
 func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte) (*malcontent.FileReport, error) {
 	if mrs == nil {
-		return &malcontent.FileReport{Path: path, Error: fmt.Sprintf("yara-x scan results are nil for %s", path)}, nil
+		return nil, fmt.Errorf("yara-x scan results are nil")
 	}
 
 	ignoreTags := c.IgnoreTags


### PR DESCRIPTION
Closes: #775 

We had a couple of instances of leveraging `fr.Error` to influence rendering behavior or take the place of actual errors.

This PR adds a new error type and a few sentinel errors to help with returning more consistent, idiomatic errors. We'll still populate `fr.Skipped` when certain errors are encountered but won't rely on the `Error` field any longer. We still use `fr.Skipped` to ignore rendering problematic files, so nothing changes there.

I also added some more `c.Renderer == nil` checks influenced by #774.
