### PR TITLE
Update sonar_analyzer_override rule with new rule name

### DIFF
--- a/rules/false_positives/sonarqube.yara
+++ b/rules/false_positives/sonarqube.yara
@@ -15,8 +15,8 @@ rule sonarqube_tutorial_app: override {
 
 rule sonar_analyzer_override: override {
   meta:
-    description                                   = "SonarQube SonarAnalyzer.CSharp.dll"
-    COD3NYM_SUSP_OBF_NET_Reactor_Indicators_Jan24 = "medium"
+    description                = "SonarQube SonarAnalyzer.CSharp.dll"
+    COD3NYM_Reactor_Indicators = "medium"
 
   strings:
     $ = "SonarAnalyzer" fullword


### PR DESCRIPTION
The overridden rule for the `sonar_analyzer_override` false-positive rule changed as part of https://github.com/chainguard-dev/malcontent/pull/780.

This PR updates the name so that we're correctly ignoring Sonarqube findings.

Old override rule name:
```
$ go run cmd/mal/mal.go --format strings scan ~/Downloads/sonarqube/usr/share/sonarqube/lib/extensions/sonar-csharp-plugin-10.6.0.109712.jar
🔎 Scanning "~/Downloads/sonarqube/usr/share/sonarqube/lib/extensions/sonar-csharp-plugin-10.6.0.109712.jar"
Matches for ~/Downloads/sonarqube/usr/share/sonarqube/lib/extensions/sonar-csharp-plugin-10.6.0.109712.jar ∴ /SonarAnalyzer.CSharp.dll [CRIT] (2 rules):
COD3NYM_Reactor_Indicators [CRIT] (9 strings):
- <PrivateImplementationDetails>{0482404F-715E-4BE8-954F-F19BCC7E025E}
- <PrivateImplementationDetails>{FFBFDFC5-A8A9-45AC-BE7F-7BCD1055FA33}
- <PrivateImplementationDetails>{19A74684-3D27-4FAA-9629-040D59FF362A}
- <PrivateImplementationDetails>{6C4959E0-2B12-469C-A21F-CA01EBE0D816}
- <Module>{9AD3E85C-CFD0-40BA-BA97-E63881E20BC6}
- <Module>{62401185-271C-45D4-A3E1-60C6EA4A4284}
- <Module>{A4FFA846-67E4-40BE-BCC2-2B563FBE7E5E}
- <Module>{C472FE7D-53C8-46DC-90BA-284799317002}
- <Module>{A8F4744B-9DD9-4216-89BB-48C75F31289A}
sonar_analyzer_override [LOW] (4 strings):
- https://www.sonarsource.com
- SonarAnalysisContextBase
- SonarCodeFixContext
- SonarAnalyzer

💡 For detailed analysis, try "mal analyze <path>"
```

Updated override rule name:
```
$ go run cmd/mal/mal.go --format strings scan ~/Downloads/sonarqube/usr/share/sonarqube/lib/extensions/sonar-csharp-plugin-10.6.0.109712.jar
🔎 Scanning "~/Downloads/sonarqube/usr/share/sonarqube/lib/extensions/sonar-csharp-plugin-10.6.0.109712.jar"

💡 For detailed analysis, try "mal analyze <path>"
```