### PR TITLE
sonarcube false positives: handle renamed rule

### DIFF
--- a/rules/false_positives/sonarqube.yara
+++ b/rules/false_positives/sonarqube.yara
@@ -15,8 +15,8 @@ rule sonarqube_tutorial_app: override {
 
 rule sonar_analyzer_override: override {
   meta:
-    description                                   = "SonarQube SonarAnalyzer.CSharp.dll"
-    COD3NYM_SUSP_OBF_NET_Reactor_Indicators_Jan24 = "medium"
+    description                = "SonarQube SonarAnalyzer.CSharp.dll"
+    COD3NYM_Reactor_Indicators = "medium"
 
   strings:
     $ = "SonarAnalyzer" fullword


### PR DESCRIPTION
In commit 3147dd11 ("Update third-party rules as of 2025-01-26 (#780)"), the the YARAForge rule for detecting Eziriz .NET Reactor obfuscated DLLs was renamed from `COD3NYM_SUSP_OBF_NET_Reactor_Indicators_Jan24` to `COD3NYM_Reactor_Indicators`.

However, this rule has a false positive exception because it seems Sonarqube uses this obfuscator on its CSharp and VBWeb plugin DLLs, but the exception rule was not updated at the same time the rule was renamed. Fix that.

[Verified that none of the other rule names in the third-party rules update that changed are referenced in the false_positives directory.]