### PR TITLE
Add initial support for image diffing

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -104,7 +104,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 
 	// Clean up the path if scanning an archive
 	var clean string
-	if isArchive {
+	if isArchive || c.OCI {
 		pathAbs, err := filepath.Abs(path)
 		if err != nil {
 			return nil, NewFileReportError(err, path, TypeGenerateError)
@@ -113,14 +113,16 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 		if err != nil {
 			return nil, NewFileReportError(err, path, TypeGenerateError)
 		}
-		fr.ArchiveRoot = archiveRootAbs
-		fr.FullPath = pathAbs
+		if runtime.GOOS == "darwin" {
+			pathAbs = strings.TrimPrefix(pathAbs, "/private")
+			archiveRootAbs = strings.TrimPrefix(archiveRootAbs, "/private")
+		}
 		clean = formatPath(cleanPath(pathAbs, archiveRootAbs))
 	}
 
 	// If absPath is provided, use it instead of the path if they are different.
 	// This is useful when scanning images and archives.
-	if absPath != "" && absPath != path && isArchive {
+	if absPath != "" && absPath != path && (isArchive || c.OCI) {
 		if len(c.TrimPrefixes) > 0 {
 			absPath = report.TrimPrefixes(absPath, c.TrimPrefixes)
 		}

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/malcontent/pkg/action"
 	"github.com/chainguard-dev/malcontent/pkg/malcontent"
 	"github.com/chainguard-dev/malcontent/pkg/render"
@@ -169,7 +170,7 @@ func prepareRefresh(ctx context.Context, rc Config) ([]TestData, error) {
 }
 
 // executeRefresh reads from a populated slice of TestData.
-func executeRefresh(ctx context.Context, c Config, testData []TestData) error {
+func executeRefresh(ctx context.Context, c Config, testData []TestData, logger *clog.Logger) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	var mu sync.Mutex
@@ -187,7 +188,7 @@ func executeRefresh(ctx context.Context, c Config, testData []TestData) error {
 				var res *malcontent.Report
 
 				if len(data.Config.ScanPaths) == 2 {
-					res, err = action.Diff(ctx, *data.Config)
+					res, err = action.Diff(ctx, *data.Config, logger)
 				} else {
 					res, err = action.Scan(ctx, *data.Config)
 				}
@@ -219,7 +220,7 @@ func executeRefresh(ctx context.Context, c Config, testData []TestData) error {
 }
 
 // Refresh updates all relevant test data in pkg/action and tests.
-func Refresh(ctx context.Context, rc Config) error {
+func Refresh(ctx context.Context, rc Config, logger *clog.Logger) error {
 	if rc.SamplesPath == "" {
 		return fmt.Errorf("sample location is required")
 	}
@@ -243,5 +244,5 @@ func Refresh(ctx context.Context, rc Config) error {
 		return fmt.Errorf("failed to prepare sample data refresh: %w", err)
 	}
 
-	return executeRefresh(ctx, rc, testData)
+	return executeRefresh(ctx, rc, testData, logger)
 }

--- a/tests/samples_test.go
+++ b/tests/samples_test.go
@@ -356,7 +356,7 @@ func TestDiff(t *testing.T) {
 
 			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
 			ctx := clog.WithLogger(context.Background(), logger)
-			res, err := action.Diff(ctx, mc)
+			res, err := action.Diff(ctx, mc, logger)
 			if err != nil {
 				t.Fatalf("diff failed: %v", err)
 			}
@@ -423,7 +423,7 @@ func TestDiffFileChange(t *testing.T) {
 
 			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
 			ctx := clog.WithLogger(context.Background(), logger)
-			res, err := action.Diff(ctx, mc)
+			res, err := action.Diff(ctx, mc, logger)
 			if err != nil {
 				t.Fatalf("diff failed: %v", err)
 			}
@@ -490,7 +490,7 @@ func TestDiffFileIncrease(t *testing.T) {
 
 			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
 			ctx := clog.WithLogger(context.Background(), logger)
-			res, err := action.Diff(ctx, mc)
+			res, err := action.Diff(ctx, mc, logger)
 			if err != nil {
 				t.Fatalf("diff failed: %v", err)
 			}


### PR DESCRIPTION
This PR adds initial support for image diffs. It requires a bit of creativity to only scan the temporary directories while still treating the paths/map keys like we would for single image scans.

This is really only intended for different versions of the same image, but it does work.

[Very] brief excerpt for `python:3.13.2-alpine3.20` and `python:3.13.2-alpine3.21`:
```
├─ 🟡 Deleted: python:3.13.2-alpine3.20 ∴ /libncursesw.so.6.4 [MEDIUM]
│     ≡ cryptography [LOW]
│       🔵 rc4 — RC4 key scheduling algorithm, by Thomas Barabosch: $cmp_e_x_256, $cmp_r_x_256
│     ≡ discovery [LOW]
│       🔵 process/egid — returns the effective group id of the current process: getegid
│       🔵 process/euid — returns the effective user id of the current process: geteuid
│       🔵 process/pid — gets the active process ID: getpid
│       🔵 process/uid — returns the user id of the current process: getuid
│       🔵 process/working_directory — gets current working directory: getcwd
│       🔵 user/HOME — Looks up the HOME directory for the current user: getenv
│     ≡ evasion [MEDIUM]
│       🟡 file/prefix — hidden path generated dynamically: %s/.terminfo
│     ≡ execution [MEDIUM]
│       🔵 shell/TERM — Look up or override terminal settings: TERM
│       🔵 tty/curses — uses the curses terminal database: set_curterm, setupterm, vidputs
│       🔵 tty/isa — checks if file handle refers to a terminal: isatty
│       🟡 tty/parameters_get — get terminal parameters: cfgetospeed
│       🔵 tty/terminfo — uses the terminfo capability database
│     ≡ filesystem [LOW]
│       🔵 directory/create — creates directories: mkdir
│       🔵 file/delete — deletes files: unlink
│       🔵 file/open — opens files: fclose, fopen
│       🔵 file/stat — access filesystem information: _stat
│       🔵 path/etc — path reference within /etc: /etc/terminfo
│     ≡ operating-system [NONE]
│       🔵 env/get — Retrieve environment variables: getenv
│       🔵 env/set — places a variable into the environment: setenv
│       🔵 fd/access — Access file descriptors: _fopen
│       🔵 fd/read — Read binary from a file descriptor: fread
│       🔵 fd/write — write binary to file descriptor: fwrite
│       🔵 signal/handle — libc: sigismember, sigaction
│       🔵 signal/mask — sigprocmask
│     ≡ privesc [LOW]
│       🔵 setuid — set user identity used for filesystem checks: setfsuid
│     ≡ process [NONE]
│       🔵 chdir — changes working directory: chdir
│
├─ 🛑 Deleted: python:3.13.2-alpine3.20 ∴ /python:3.13.2-alpine3.20.tar3480989389 [HIGH]
│     ≡ anti-static [MEDIUM]
│       🟡 obfuscation/hex — converts hex data to ASCII: unhexlify
│       🟡 obfuscation/python — aliases core python library to an alternate name:
│          from cryptography import __version__ as cryptography_version, from _thread import allocate_lock as _thread_allocate_lock, from _ctypes i…
│     ≡ collection [MEDIUM]
│       🟡 archives/unarchive — unarchives files
│       🟡 archives/zip — Works with zip files: ZIP archive, zipfile, ZIP64
│       🟡 databases/mysql — accesses MySQL databases: mysql
│       🟡 databases/postgresql — accesses PostgreSQL databases: postgresql
│       🟡 databases/sqlite — accesses SQLite databases: sqlite3
│     ≡ command & control [MEDIUM]
│       🟡 addr/http_dynamic — URL that is dynamically generated: https://%s, http://%s
│       🟡 addr/ip — mentions an IP and port:
│          default_port, request_port, display_port, changed_port, tunnel_port, secure_port, server_port, parsed_port, actual_port, origin_port, re…
│       🟡 addr/server — references a 'server address', possible C2 client: _forkserver_address
│       🔵 tool_transfer/arch — references a specific architecture: https://, http://, x86_64, AMD64, arm64, amd64
│       🟡 tool_transfer/download — accesses hardcoded archive file endpoint:
│          https://github.com/jaraco/keyring/blob/97689324abcf01bd1793d49063e7ca01e03d7d07/keyring/backend.py, https://github.com/python/cpython/bl…
│       🟡 tool_transfer/os — references multiple operating systems: https://, Windows, http://, Darwin, Linux, macOS
│     ≡ credential [HIGH]
│       🟡 gaming/minecraft — Has references to Minecraft: minecraft
│       🟡 keychain — accesses a keychain: Keychain
│       🟡 os/gshadow — accesses /etc/gshadow (group passwords)
│       🟡 os/shadow — accesses /etc/shadow
│       🔵 password — references a 'password':
│          -username and --password options instead, keyfile and key_password is None and _is, uses a one-time password and a temporary, -username …
│       🟡 sniffer/bpf — BPF (Berkeley Packet Filter): bpf
│       🟡 ssh/d — Mentions SSHD: sshd
│       🛑 ssh/d_memory_map — May access the memory map for sshd: password, tracer, passwd, ptrace
│       🟡 ssl/private — access SSL private key material: /etc/ssl/private
│       🔵 ssl/private_key — References private keys: private_key, PRIVATE_KEY, privateKey, privatekey
│     ≡ cryptography [MEDIUM]
│       🔵 aes — Supports AES (Advanced Encryption Standard): aes_256_cbc, crypto/aes
│       🟡 cipher — mentions 'ciphertext'
│       🔵 decrypt — decrypts data:
│          evp_EncryptDecryptUpdate, Decrypt a bytes object, EVP_DecryptFinal_ex, EVP_DecryptInit_ex2, EVP_DecryptUpdate, def _ZipDecrypter
│       🔵 ed25519 — Elliptic curve algorithm used by TLS and SSH: ed25519
│       🔵 gost89 — Uses the GOST89 block cipher
│       🟡 openssl — Uses OpenSSL: openssl
│       🔵 public_key — references a 'public key': Public key, public_key, Public Key, Public-Key, public-key, PublicKey, publicKey, publickey
│       🔵 ssl — uses Python SSL library: ssl.create_default_context, import ssl
│       🔵 tls — tls: TLSVersion, TLS13
│     ≡ data [MEDIUM]
│       🟡 base64/decode — decode base64 strings: base64_decode::b64decode
│       🟡 base64/encode — encode base64 strings: base64_encode::b64encode
│       🔵 compression/bzip2 — Works with bzip2 files
│       🔵 compression/gzip — works with gzip files
│       🔵 compression/lzma — works with lzma files
│       🔵 compression/zlib — uses zlib
│       🔵 compression/zstd — Zstandard: fast real-time compression algorithm: zstd
│       🟡 embedded/app_manifest — Contains embedded Microsoft Windows application manifest: requestedExecutionLevel, requestedPrivileges
│       🟡 embedded/base64_terms — Contains base64 CERTIFICATE:
│          contains_base64::Q0VSVElGSUNBVE, contains_base64::DRVJUSUZJQ0FUR, contains_base64::ZGlyZWN0b3J5, contains_base64::RpcmVjdG9ye
│       🟡 embedded/base64_url — Contains base64 url: contains_base64_url::aHR0cDovL, contains_base64_url::odHRwOi8v, contains_base64_url::h0dHA6Ly
│       🟡 embedded/html — Contains HTML content: DOCTYPE html, <html lang, <html>
│       🔵 embedded/pem_certificate — Contains embedded PEM certificate: -----BEGIN CERTIFICATE-----
│       🔵 embedded/svg — Contains SVG (Scalable Vector Graphics) content: </svg>, <svg>
│       🔵 encoding/base64 — Supports base64 encoded strings
│       🔵 encoding/json_decode — Decodes JSON messages: JSONDecode, json.loads
│       🔵 encoding/json_encode — encodes JSON: JSONEncode
│       🔵 encoding/protobuf — protobuf
│       🔵 hash/blake2b — Uses blake2b encryption algorithm
│       🔵 hash/md5 — Uses the MD5 signature format:
│          MD5_DIGEST_LEN, MD5_Transform, MD5_ROUTINES, MD5_CFLAGS, MD5_Update, MD5_Final, MD5_STATE, MD5_AUTH, MD5_DEPS, MD5_Init
│       🔵 hash/sha1 — Uses the SHA1 signature format: SHA1_
│       🔵 hash/sha256 — Uses the SHA256 signature format: SHA256_
│       🔵 hash/sha512 — Uses the SHA512 signature format
│       🟡 hash/whirlpool — hash function often used for cryptomining: WHIRLPOOL
│       🔵 random/insecure — generate random numbers insecurely: _rand, srand
│     ≡ discovery [MEDIUM]
│       🟡 group/lookup — get entry from group database: getgrent, setgrent, endgrent
│       🔵 network/interface — get network interfaces by name or index: if_freenameindex, if_indextoname, if_nametoindex, if_nameindex
│       🟡 network/interface_list — list network interfaces: /proc/net/dev, freeifaddrs, getifaddrs, ifconfig
│       🟡 network/mac_address — Retrieves network MAC address
│       🟡 network/netstat — Uses 'netstat' for network information
│       🔵 process/egid — returns the effective group id of the current process: getegid
│       🔵 process/euid — returns the effective user id of the current process: geteuid
│       🟡 process/name — get the current process name: process_name, processName
│       🔵 process/parent — gets parent process ID: getppid
│       🔵 process/pid — gets the active process ID: getpid
│       🔵 process/priority — getpriority
│       🔵 process/resource_limits — retrieve resource limits: getrlimit
│       🟡 process/runtime_deps — looks up thread private variables, may be used for loaded library discovery: __tls_get_addr
│       🔵 process/uid — returns the user id of the current process: getuid
│       🔵 process/working_directory — gets current working directory: "pwd", 'pwd'
│       🟡 processes/pgrep — Finds program in process table: pgrep
│       🔵 system/cpu — gets number of processors: get_nprocs
│       🔵 system/dmesg — accesses the kernel log ring buffer: dmesg
│       🟡 system/environment — Dump values from the environment: os.environ.items()
│       🔵 system/hostname — get computer host name: socket.gethostname
│       🟡 system/platform — operating-system identification: os_release
│       🟡 system/sysinfo — get system information (load, swap): sysinfo
│       🟡 user/APPDATA — Looks up the 'Microsoft' application data directory for the current user: APPDATA
│       🔵 user/HOME — Looks up the HOME directory for the current user: getenv
│       🔵 user/USER — Looks up the USER name of the current user: environ, getenv, ENV
│       🟡 user/USERPROFILE — Looks up the Desktop directory for the current user: USERPROFILE
│       🔵 user/lookup — get entry from passwd (user) database: getpwuid, getpwent, getpwnam, endpwent
│       🟡 user/name_get — returns the user name running this process: whoami
│     ≡ evasion [HIGH]
│       🛑 file/location/dev_shm — reference file within /dev/shm (world writeable): /dev/shm/tmp-
│       🟡 file/location/var_run — references subfolder within /var/run: /var/run/user/, /var/run/nscd/
│       🟡 file/prefix — hidden path generated dynamically: os.path.join(location, ".gitmodules"), %s/.terminfo, %s/.netrc
│       🟡 hide_artifacts/pivot_root — change the root mount location: pivot_root
│       🟡 hijack_execution/DYLD_LIBRARY_PATH — overrides the library search path: DYLD_LIBRARY_PATH
│       🔵 hijack_execution/LD_LIBRARY_PATH — ld library path: LD_LIBRARY_PATH
│       🔵 logging/acct — switch process accounting on or off: radius-acct
│       🟡 logging/current_logins — accesses current logins: /var/log/wtmp
│       🟡 logging/dev_log — device where local syslog messages are read: /dev/log
│       🛑 process_injection/ptrace — may inject code into other processes: /proc/%d/maps, ptrace
│     ≡ execution [MEDIUM]
│       🟡 cmd — executes a command: cmdlist
│       🟡 cmd/pipe — launches program and reads its output:
│          os.popen(commandstring, os.popen because that, os.popen("osascript", os.popen()", os.popen is, _popen
│       🔵 conditional/LANG — Looks up language of current user: getenv, LANG
│       🟡 conditional/LANG_set — overrides the user-set language: export LANG=
│       🔵 dylib/address_check — determine if address belongs to a shared library: dladdr
│       🔵 dylib/iterate — iterate over list of shared objects: dl_iterate_phdr
│       🔵 dylib/open — makes use of dynamic libraries: LoadLibrary, dlclose, dlopen
│       🟡 dylib/symbol_address — get the address of a symbol: dlsym
│       🟡 dylib/windll — executes code from Windows dynamic libraries:
│          windll.kernel32.FillConsoleOutputCharacterW, windll.kernel32.FillConsoleOutputAttribute, windll.kernel32.GetConsoleScreenBufferInfo, win…
│       🔵 install_additional/pip_install — Installs software using pip from python: pip install pyopenssl
│       🔵 plugin — references a 'plugin':
│          plugin import find_plugin_filters, plugin import find_plugin_lexers, plugin import find_plugin_styles, for lexer in find_plugin_lexers, …
│       🟡 program — executes external programs: execlp, execvp, execle
│       🔵 program/background — wait for process to exit: waitpid
│       🟡 program/hidden — relative hidden launcher: ./.0.1.2., ./.pdbrc, system, popen, exec, bash
│       🔵 reconfigure/hostname_set — sethostname
│       🟡 remote_commands/code_eval — evaluate shell code dynamically using eval: eval $COMP_WORDS
│       🟡 script/osa — runs osascript
│       🔵 shell/SHELL — path to active shell: SHELL
│       🔵 shell/TERM — Look up or override terminal settings: TERM
│       🟡 shell/arbitrary_command_dev_null — runs templated commands, discards output: %s 2>/dev/null
│       🟡 shell/background_sleep — calls sleep and runs shell code in the background:
│          /usr/sbin/update-ca-certificates &>, sleep 1, sleep 0, _sleep, nohup
│       🟡 shell/busybox_exec — runs busybox programs: /bin/busybox depmod, /bin/busybox mkdir, /bin/busybox sh
│       🟡 shell/exec — executes shell: /bin/sh as the executable, /bin/sh cmd, /bin/sh -e', /bin/sh' if, /bin/sh so
│       🟡 shell/ignore_output — Runs shell commands but throws output away:
│          if which pybuildbot.identify >/dev/null 2>&1, if which readlink >/dev/null 2>&1
│       🟡 shell/pipe_sh — pipes to shell: | sh
│       🟡 shell/power — runs powershell scripts
│       🔵 system_controls/systemd — makes references to systemd
│       🔵 tty/curses — uses the curses terminal database: set_curterm, setupterm, vidputs
│       🔵 tty/getpass — prompt for a password within a terminal: getpass
│       🔵 tty/isa — checks if file handle refers to a terminal: isatty
│       🟡 tty/open — finds and opens an available pseudoterminal: openpty
│       🟡 tty/parameters_get — get terminal parameters: cfgetospeed
│       🟡 tty/pathname — returns the pathname of a terminal device: ttyname
│       🔵 tty/terminfo — uses the terminfo capability database
│       🔵 tty/vhangup — virtually hangup the current terminal: vhangup
│     ≡ exfiltration [MEDIUM]
│       🟡 collection — Uses terms that reference data collection: collect_data
│       🟡 stealer/connect_glob_exec — makes HTTPS connections, runs programs, finds files: _connect, https, _exec, _glob
│       🟡 upload — uses DropBox for cloud storage: Dropbox
│     ≡ filesystem [MEDIUM]
│       🟡 attributes/remove — remove an extended file attribute value: removexattr
│       🟡 attributes/set — set an extended file attribute value: setxattr
│       🔵 blkid — works with block device attributes: blkid
│       🔵 device_control — manipulate the device parameters of special files: ioctl
│       🔵 directory/create — creates directories: os.makedirs, mkdir
│       🔵 directory/list — Uses /bin/ls list a directory
│       🔵 directory/remove — Uses libc functions to remove directories: rmdir
│       🟡 directory/traverse — traverse filesystem hierarchy: os.walk
│       🔵 event_monitoring — filesystem event monitoring: fanotify_init
│       🔵 fifo_create — make a FIFO special file (a named pipe): mkfifo
│       🔵 file/access_check — check if the current user can access a file: faccessat, _access
│       🟡 file/copy — copy files using cp:
│          cp python-config.py python-config, cp -a var/spool/mail/, cp -a var/run/, cp -P src dst, cp in label, cp src dst, cp doesn, cp - cq, cp $
│       🟡 file/create — create a new file: CreateFileHandler, CreateFileMapping, CreateFileW
│       🟡 file/delete — delete a file: DeleteFileHandler
│       🟡 file/delete_forcibly — Forcibly deletes files recursively:
│          rm -rf iOS/testbed/Python.xcframework/i, rm -rf Python/deepfreeze, rm -rf build platform, rm -rf var/spool/mail, rm -rf iOS/Frameworks, …
│       🔵 file/exists — check if a file exists: path.exists
│       🔵 file/flags_change — May update file flags using chflags
│       🟡 file/make_executable — makes file executable: chmod +x config.guess config.sub, chmod +x $@
│       🔵 file/open — opens files: open(
│       🔵 file/open_by_handle — obtain handle for a pathname and open file via a handle: name_to_handle_at, open_by_handle_at
│       🔵 file/permission_mask_set — set file mode creation mask: umask
│       🟡 file/read — opens a binary file for read:
│          open(metadata_file.path, "rb"), open(stream_or_string, 'rb'), open(obj._file_path, "rb"), open(resource.path, 'rb'), open(self._datfile,…
│       🔵 file/rename — renames files: os.rename
│       🔵 file/stat — Access filesystem timestamps: os.path.getatime, os.path.getmtime
│       🔵 file/sync — forcibly synchronizes file state to disk: fsync
│       🟡 file/times_set — change file last access and modification times: utimes
│       🔵 file/truncate — truncate a file to a specified length: ftruncate
│       🔵 file/write — writes to file: WriteFile
│       🔵 link_create — May create hard file links: _link
│       🔵 link_read — read value of a symbolic link: readlinkat
│       🔵 lock_update — apply or remove an advisory lock on a file: flock
│       🟡 loopback — access virtual block devices (loopback): /dev/loop%u
│       🔵 mmap — mmap: _mmap
│       🔵 mount — mounts file systems: remount, fstab
│       🟡 mounts_read — Parses active mounts (/etc/fstab, /etc/mtab)
│       🔵 node_create — create device files: mknod
│       🔵 path/bin_su — Calls /bin/su
│       🔵 path/dev_null — References /dev/null
│       🔵 path/etc — path reference within /etc:
│          /etc/ssl/certs/ca-certificates.crt, /etc/ca-certificates/update.d/, /etc/httpd/conf/mime.types, /etc/ca-certificates.conf, /etc/network/…
│       🟡 path/etc_hosts — references /etc/hosts
│       🟡 path/etc_initd — references /etc/init.d: etc/init.d/acpid, etc/init.d/rcS
│       🔵 path/etc_resolv.conf — accesses DNS resolver configuration: /etc/resolv.conf
│       🔵 path/home_config — path reference within ~/.config: ~/.config/pip
│       🔵 path/home_library — path reference within ~/Library:
│          ~/Library/Logs/ for use with the Console, ~/Library/Caches/TemporaryItems/, ~/Library/Application Support/, ~/Library/Preferences/, ~/Li…
│       🟡 path/root — path reference within /root
│       🟡 path/tmp — path reference within /tmp:
│          /tmp/tmpfile_XXX/tmp/tmpnam_XXXX, /tmp/myimport.zip/mydirectory, /tmp/_aix_support.%s, /tmp/_osx_support.%s, /tmp/perf-%jd.map, /tmp/res…
│       🟡 path/users — references path within /Users: /Users/foo
│       🔵 path/usr_bin — path reference within /usr/bin:
│          /usr/bin/startsomethingwith, /usr/bin/python-ruby, /usr/bin/run-parts, /usr/bin/python2.4, /usr/bin/c_rehash, /usr/bin/install, /usr/bin…
│       🟡 path/usr_lib_python — References paths within /usr/lib/python: /usr/lib/python3/dist-packages
│       🟡 path/usr_local — path reference within /usr/local/bin: /usr/local/bin/python3.13
│       🔵 path/usr_sbin — path reference within /usr/sbin: /usr/sbin/update-ca-certificates
│       🔵 path/var — path reference within /var:
│          /var/www/html/python/index.html, /var/lib/libuuid/clock-cont.txt, /var/run/dhclient.%iface%.pid, /var/run/udhcpc.%iface%.pid, /var/lib/l…
│       🟡 path/var_log — path reference within /var/log: /var/log/acpid.log, /var/log/messages, /var/log/wtmp
│       🔵 permission/chown — May change file ownership: fchown
│       🟡 permission/modify — modifies file permissions: _setmode, chmod
│       🟡 proc/arbitrary_pid — access /proc for arbitrary pids:
│          /proc/%u/cmdline, /proc/%u/smaps, /proc/%u/task/, /proc/%d/maps, /proc/%u/fd/, /proc/%u/cwd, /proc/%u/ns/
│       🟡 proc/meminfo — get memory info: /proc/meminfo
│       🟡 proc/mounts — Parses active mounts (/proc/mounts
│       🟡 proc/net_dev — network device statistics: /proc/net/dev
│       🟡 proc/net_route — gets network route information: /proc/net/route
│       🟡 proc/pid_maps — access process memory maps: /proc/%d/maps
│       🟡 proc/self_exe — gets executable associated to this process: /proc/self/exe
│       🟡 proc/self_status — gets status associated to this process, including capabilities: /proc/self/status
│       🟡 proc/stat — gets kernel/system statistics: /proc/stat
│       🔵 quota_manipulate — manipulate disk quota: quotactl
│       🔵 swap/off — stop swapping to a file/device: swapoff
│       🔵 swap/on — start swapping to a file/device: swapon
│       🔵 symlink_create — creates symbolic links: symlinkat
│       🔵 symlink_resolve — resolves symbolic links: realpath
│       🔵 tempdir — looks up location of temp directory: gettempdir, TEMPDIR, TMPDIR
│       🔵 tempdir/TEMP — temp: os.environ, getenv, TEMP
│       🔵 tempdir/TMPDIR — TMPDIR: getenv
│       🔵 tempdir/create — creates temporary directory: temp dir, mkdtemp
│       🔵 tempfile — creates temporary files: temp file, tmpfile, mktemp
│       🔵 unmount — unmount file system: umount
│       🔵 watch — monitors filesystem events: inotify
│     ≡ hardware [MEDIUM]
│       🟡 cpu — Get information about CPUs: /sys/devices/system/cpu
│       🟡 dev/block_ice — access raw generic block devices: /sys/block
│       🔵 urandom — references /dev/urandom
│     ≡ impact [MEDIUM]
│       🟡 ddos/raw_flooder — raw sockets with multiple targets, possible DoS or security scanning tool: HDRINCL, pthread, flood, srand
│       🟡 degrade/linux_paths — accesses multiple critical Linux paths:
│          /tmp/tmpfile_XXX/tmp/tmpnam_XXXX, /tmp/myimport.zip/mydirectory, /sys/devices/system/node/node, /sbin/update-ca-certificates, /usr/libex…
│       🟡 exploit — References an exploit: Exploit
│       🟡 infection/worm — References 'Worm': worm
│       🟡 reboot — Forcibly reboots machine: /sbin/reboot
│       🟡 remote_access/heartbeat — references a 'heartbeat':
│          implement a monotonic heartbeat, unsigned long long  heartbeat, unsigned long long heartbeat, monotonic heartbeat count
│       🟡 remote_access/kill_rm — kills and removes programs via the command-line: killall, rm -rf, rm -f, pgrep, pkill
│       🟡 remote_access/pseudo_terminal — pseudo-terminal access functions: posix_openpt, unlockpt, ptsname, grantpt
│       🔵 ui/parses_arguments — parse command-line arguments: argparse, getopts, optarg
│     ≡ lateral [LOW]
│       🔵 scan/brute_force — May use bruteforce to function: brute force
│     ≡ mem [MEDIUM]
│       🔵 advise — give advice about use of memory: madvise
│       🟡 anonymous_file — create an anonymous file: memfd_create
│       🔵 lock — lock a processes virtual address space: mlockall, mlock2
│       🔵 mprotect — mprotect
│     ≡ networking [MEDIUM]
│       🟡 dns/reverse — looks up the reverse hostname for an IP: .in-addr.arpa, ip6.arpa
│       🔵 dns/servers — Examines local DNS servers: resolv.conf
│       🔵 dns/txt — Uses DNS TXT (text) records: dns
│       🟡 download/fetch — Invokes curl to download a file:
│          curl and lynx use this file format, curl and modern browsers., curl -sL -o config.guess, curl -sL -o config.sub
│       🟡 email/exotic_addr — Contains an exotic email address: cielesti@protonmail.com
│       🔵 ftp — File Transfer Protocol (FTP): EPSV
│       🔵 http/2 — Uses the HTTP/2 protocol
│       🟡 http/accept — accepts binary files via HTTP: application/octet-stream, Accept
│       🔵 http/accept_encoding — set HTTP response encoding format (example: gzip): Accept-Encoding
│       🔵 http/auth — makes HTTP requests with basic authentication: WWW-Authenticate, www-authenticate
│       🟡 http/content_length — Sets HTTP content length to zero: Content-Length: 0
│       🟡 http/cookies — access HTTP resources using cookies: http_cookie, HTTP_COOKIE, Cookie
│       🟡 http/form_upload — upload content via HTTP form: application/x-www-form-urlencoded, application/json, POST, post
│       🟡 http/post — submits form content to websites:
│          Content-Type header in the original message., Content-Type and has not yet been defined fo, Content-Type field.  Anything else will gene…
│       🔵 http/proxy — use HTTP proxy that requires authentication: Proxy-Authorization
│       🔵 http/request — makes HTTP requests: HTTPSConnection, HTTPConnection, httpConnect, User-Agent, HTTP/1., Referer
│       🟡 ip/host_port — connects to an arbitrary hostname:port:
│          host on a given port, host, _ = _splitport, host, port=self.port, host=self.host, port, host, self.mailport, hostport(host, port, host i…
│       🟡 ip/icmp — Uses the ping tool to generate ICMP packets: ping statistics ---, ping Chung
│       🔵 ip/multicast_send — send data to multiple nodes simultaneously: multicast
│       🟡 ip/parse — parses IP address (IPv4 or IPv6): inet_addr
│       🔵 ip/resolve — resolves network hosts via IP address: gethostbyaddr
│       🔵 ip/send_unicast — send data to the internet: unicast
│       🟡 ip/spoof — references spoofing: Prevents ip spoofing, class _SpoofOut
│       🟡 ip/string — converts IP address from byte to string: inet_ntoa, inet_ntop
│       🟡 ip/syncookie — references SYN cookies, used to resist DoS attacks: syncookie
│       🟡 proxy/tunnel — creates a network tunnel: inet_addr
│       🔵 resolve/hostname — resolve network host name to IP address: gethostbyname
│       🔵 resolve/hostport_parse — Network address and service translation: freeaddrinfo, getaddrinfo
│       🟡 rpc/ntlm — supports Windows NTLM authentication: ntlm
│       🟡 socket/connect — initiate a connection on a socket: _connect
│       🟡 socket/listen — generic listen string: socket, accept
│       🔵 socket/local_addr — get local address of connected socket: getsockname
│       🔵 socket/options_get — get socket options: getsockopt
│       🔵 socket/options_set — set socket options: setsockopt
│       🟡 socket/pair — create a pair of connected sockets: socketpair
│       🔵 socket/peer_address — get peer address of connected socket: client_address, getpeername
│       🟡 socket/raw — send raw and/or malformed IP packets: /proc/net/raw, IPPROTO_RAW, raw socket, SOCK_RAW, HDRINCL
│       🔵 socket/receive — receive a message from a socket: recvfrom, recvmsg, _recv
│       🟡 socket/reuseport — reuse TCP/IP ports for listening and connecting: SO_REUSEADDR, SO_REUSEPORT
│       🔵 socket/send — send a message to a socket: sendmmsg, sendmsg, sendto, _send
│       🟡 ssl/no_verify — disables SSL verification:
│          verify_mode(ctx, ssl.CERT_NONE, verify_mode == ssl.CERT_NONE, verify_mode != ssl.CERT_NONE, verify_mode = ssl.CERT_NONE
│       🟡 ssl/socket — manually encrypts a socket with SSL:
│          .wrap_socket(sock, server_hostname=server_hostname), .wrap_socket(sock, server_hostname=host) as sslsock, .wrap_socket(self.sock, server…
│       🟡 tcp/sftp — Supports sftp (FTP over SSH): ssh
│       🟡 tcp/ssh — Supports SSH (secure shell): secureShellClient
│       🟡 tun_tap — accesses the TUN/TAP device driver: /dev/net/tun
│       🟡 url/embedded — contains hardcoded PHP endpoint:
│          https://en.wikipedia.org/w/index.php?title=MAC_address, https://opensource.org/licenses/mit-license.php
│       🟡 url/encode — encodes URL, likely to pass GET variables: urlencode
│       🔵 url/parse — Handles URL strings: urllib, NSURL
│       🟡 url/request — requests resources via URL: import requests, urllib.request, requests.get(, http.request, openURL
│     ≡ operating-system [LOW]
│       🔵 env/get — Retrieve environment variable values:
│          os.environ["USERPROFILE"], os.environ['USERPROFILE'], os.environ['PYTHONPATH'], os.environ['ARCHFLAGS'], os.environ['HOMEPATH'], os.envi…
│       🔵 env/set — places a variable into the environment: SetEnvironmentVariableW, setenv, putenv
│       🔵 env/unset — unsetenv
│       🔵 fd/access — Access file descriptors: fmemopen, _rewind, freopen, fdopen, _fopen
│       🔵 fd/epoll — I/O event notification facility: epoll_create, epoll_wait
│       🔵 fd/manipulate — manipulate file descriptor with fcntl
│       🔵 fd/print — print to file descriptor: dprintf
│       🔵 fd/read — reads from a file handle:
│          process_python_str(tokenizer.read(), process_env_var(tokenizer.read(), parse_requires_data(fp.read(), exec(open(filename).read(), exec(o…
│       🔵 fd/sendfile — transfer data between file descriptors: sendfile
│       🔵 fd/write — writes to a file handle:
│          f.write(NETSCAPE_HEADER_TEXT), stdout.write(continue_prompt), self.write(READONLY_BUFFER), _transport.writelines(data), rf_file.writelin…
│       🔵 kernel/netlink — communicate with kernel services: AF_NETLINK, netlink
│       🔵 kernel/sysctl — get or set kernel stat: sysctl
│       🔵 service/syslog — Use the syslog (system log) service
│       🔵 signal/handle — Adds or removes handler function for the calling process: SetConsoleCtrlHandler
│       🔵 signal/handle_ALRM — Listen for SIGALRM (timeout) events: sigaction
│       🔵 signal/handle_HUP — Listen for SIGHUP (hangup) events: sigaction
│       🔵 signal/handle_INFO — Listen for SIGINFO (information) events: sigaction
│       🔵 signal/handle_INT — Listen for SIGINT (ctrl-C) events: sigaction
│       🔵 signal/handle_QUIT — Listen for SIGQUIT (kill) events: sigaction
│       🔵 signal/handle_WINCH — Listen for SIGWINCH (terminal window change) events: sigaction
│       🔵 signal/mask — sigprocmask
│       🔵 signal/send — kill: process.kill
│       🔵 time/clock_convert — bsd time conversion: localtime, difftime, asctime, gmtime, mktime, timegm
│       🔵 time/clock_get — bsd time: _time
│       🔵 time/clock_set — set time via system clock: adjtime
│       🔵 time/clock_sleep — uses sleep to wait: _sleep
│       🔵 time/tzinfo — Uses timezone information: tzinfo, tzdata
│     ≡ persistence [MEDIUM]
│       🟡 cron/tab — lists crontab entries, may also persist
│       🟡 kernel_module/unload — Unload Linux kernel module: delete_module
│       🟡 pid_file — pid file, likely DIY daemon: /run/acpid.pid
│     ≡ privesc [MEDIUM]
│       🔵 setuid — set real and effective user ID of current process: setuid
│       🟡 sudo — calls sudo: sudo pip still writes to virtualenv., sudo without -H flag., sudo users on Unix., sudo's -H flag.
│     ≡ process [MEDIUM]
│       🔵 chdir — changes working directory: cd - offset_cd, cd Mac, cd \"$, cd to, cd $
│       🔵 chroot — change the location of root for the process: chroot
│       🔵 create — create child process: _fork
│       🟡 executable_path — gets executable associated to this process: sys.executable
│       🔵 group/create — creates a session and sets the process group ID: setsid
│       🔵 group/set — setpgid: setpgrp
│       🔵 groupid_set — set real, effective, and saved group ID of process: setgid
│       🔵 groups_set — set group access list: setgroups
│       🔵 limit_set — set resource limits: setrlimit
│       🟡 multi — uses python multiprocessing
│       🟡 multithreaded — uses python threading: threading.Thread
│       🟡 name_set — get or set the current process name: __progname
│       🔵 namespace_set — associate thread or process with a namespace: setns
│       🔵 pthreads — Uses pthreads: pthread_cond_init, pthread_cond_wait, pthread_join
│       🔵 setpriority — adjust the process nice value: renice
│       🟡 terminate — terminate a process: TerminateProcess
│       🟡 terminate/kill_multiple — kills multiple processes by name: killall python
│       🔵 unshare — disassociate parts of the process execution context: unshare
│     ≡ suspicious text [MEDIUM]
│       🟡 exclamation — gets very excited:
│          used to write into the frames local dictionary!!, This file is edited by the makesetup script !!!, release tag for new entries above!!!,…
│       🟡 intercept — References interception: interceptors, intercepted
│       🟡 lang — hardcodes language to American English: en_US.UTF-8
│       🟡 leetspeak — References 1337 terminology'
│       🟡 malicious — References 'malicious':
│          the possibly malicious import of a, be used to maliciously alter hosts, embedded in malicious packages, ignoring malicious file, malicio…
│
...
├─ 🔵 Added: python:3.13.2-alpine3.21 ∴ /liblzma.so.5.6.3 [LOW]
│     ≡ data [LOW]
│       🔵 compression/lzma — works with lzma files
│     ≡ operating-system [NONE]
│       🔵 fd/access — Access file descriptors: _rewind
│     ≡ process [LOW]
│       🔵 multithreaded — creates pthreads: pthread_create
│       🔵 pthreads — Uses pthreads: pthread_cond_init, pthread_cond_wait, pthread_join
│       🔵 setpriority — adjust the process nice value
...
├─ 🟡 Changed (3 added, 2 removed): python:3.13.2-alpine3.21 ∴ /usr/local/lib/python3.13/idlelib/util.py
│+    ▲ command & control [NONE → LOW]
│+      🔵 tool_transfer/os — references a specific operating system: https://, Windows
│+    ▲ discovery [NONE → MEDIUM]
│+      🟡 system/platform — system platform identification: sys.platform
│     ≡ execution [LOW]
│     ≡ networking [LOW]
│-      🔵 http/request — makes HTTP requests
│-      🔵 url/parse — Handles URL strings
│+      🔵 url/embedded — contains embedded HTTPS URLs: https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512
│
├─ 🔵 Changed (0 added, 1 removed): python:3.13.2-alpine3.21 ∴ /usr/local/lib/python3.13/site-packages/pip-24.3.1.dist-info/LICENSE.txt
│     ≡ networking [LOW]
│-      🔵 url/embedded — contains embedded HTTPS URLs
│
├─ 🔵 Changed (1 added, 5 removed): python:3.13.2-alpine3.21 ∴ /usr/local/lib/python3.13/site-packages/pip/_vendor/urllib3/exceptions.py
│     ≡ anti-static [LOW]
│-      🔵 obfuscation/python — joins array together with an empty delimiter
│     ≡ execution [MEDIUM]
│-      🟡 install_additional/pip_install — Installs software using pip from python
│-      🟡 program — execute external program
│     ≡ networking [MEDIUM]
│-      🟡 download — download files
│+      🔵 url/parse — Handles URL strings: urllib
│     ≡ suspicious text [MEDIUM]
│-      🟡 malicious — References 'malicious'
│
├─ 🔵 Changed (0 added, 9 removed): python:3.13.2-alpine3.21 ∴ /usr/local/lib/python3.13/asyncio/queues.py
│     ≡ discovery [MEDIUM]
│-      🔵 process/pid — gets the active process ID
│-      🟡 system/platform — system platform identification
│     ≡ execution [LOW]
│     ≡ networking [LOW]
│-      🔵 socket/receive — receive a message from a socket
│-      🔵 socket/send — send a message to a socket
│     ≡ operating-system [NONE]
│-      🔵 fd/access —  close
│     ≡ persistence [MEDIUM]
│-      🟡 daemon — Run as a background daemon
│     ≡ process [MEDIUM]
│-      🔵 create — create child process
│-      🟡 multi — uses python multiprocessing
│-      🟡 multithreaded — uses python threading
│
├─ 🟡 Changed (1 added, 0 removed): python:3.13.2-alpine3.21 ∴ /usr/local/lib/python3.13/lib-dynload/_xxtestfuzz.cpython-313-x86_64-linux-musl.so
│     ≡ anti-static [MEDIUM]
│+      🟡 binary/opaque — binary contains little text content: fuzz input
...
```

This has no impact on non-image diffs and I verified this with several refreshes.