### PR TITLE
Reduce false positives/increase signal for various languages, tools, and packages

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -36,6 +36,7 @@ var badRules = map[string]bool{
 	"SECUINFRA_SUSP_Powershell_Base64_Decode":             true,
 	"SIGNATURE_BASE_SUSP_ELF_LNX_UPX_Compressed_File":     true,
 	"DELIVRTO_SUSP_SVG_Foreignobject_Nov24":               true,
+	"CAPE_Eternalromance":                                 true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,

--- a/rules/anti-static/base64/obfuscated_caller.yara
+++ b/rules/anti-static/base64/obfuscated_caller.yara
@@ -14,6 +14,8 @@ rule obfuscated_caller_base64_str_replace: critical {
     $i = "'b'.'ase'.'6'.'4"
     $j = "'bas'.'e'.'6'.'4"
 
+    $not_unrelated1 = "_bias_eb604"
+
   condition:
-    any of them
+    any of them and none of ($not*)
 }

--- a/rules/evasion/mimicry/fake-process.yara
+++ b/rules/evasion/mimicry/fake-process.yara
@@ -3,11 +3,13 @@ rule fake_kworker: critical linux {
     description = "Pretends to be a kworker kernel thread"
 
   strings:
-    $kworker  = /\[{0,1}kworker\/[\w\%:\-\]]{1,16}/
-    $kworker3 = "[kworker"
+    $kworker1 = /\[{0,1}kworker\/[\w\%:\-\]]{1,16}/
+    $kworker2 = "[kworker"
+
+    $not_rescue = "kworker/R-%s"
 
   condition:
-    filesize < 100MB and any of ($k*)
+    filesize < 100MB and any of ($kworker*) and none of ($not*)
 }
 
 rule kworker: medium linux {

--- a/rules/exfil/stealer/wallet.yara
+++ b/rules/exfil/stealer/wallet.yara
@@ -30,6 +30,9 @@ rule crypto_stealer_names: critical {
     $not_js          = /\"js\": \{[^}]{0,64}/
     $not_scriptsrc   = /\"scriptSrc\": "([^"]{0,64})"/
     $not_website     = /\"website\": "([^"]{0,64})"/
+    $not_geth_mod    = "github.com/ethereum/go-ethereum"
+    $not_clef        = "github.com/ethereum/go-ethereum/cmd/clef/main.go"
+    $not_geth        = "github.com/ethereum/go-ethereum/cmd/geth/main.go"
 
   condition:
     filesize < 100MB and $http and 2 of ($w*) and none of ($not*)

--- a/rules/false_positives/gitlab.yara
+++ b/rules/false_positives/gitlab.yara
@@ -1,0 +1,15 @@
+rule exec_regex: override {
+  meta:
+    description                         = "csv_builder_spec.rb"
+    SEKOIA_Technique_Csv_Dde_Exec_Regex = "low"
+
+  strings:
+    $example1 = "shared_examples 'excel sanitization' do"
+    $example2 = "'sanitizes dangerous characters at the beginning of a column'"
+    $example3 = "'does not sanitize safe symbols at the beginning of a column'"
+    $example4 = "'when dangerous characters are after a line break'"
+    $example5 = "'does not append single quote to description'"
+
+  condition:
+    filesize < 8192 and all of them
+}

--- a/rules/false_positives/ltp.yara
+++ b/rules/false_positives/ltp.yara
@@ -1,0 +1,16 @@
+rule dirty_pipe_test: override {
+  meta:
+    ELASTIC_Linux_Exploit_CVE_2022_0847_E831C285  = "low"
+    SIGNATURE_BASE_WEBSHELL_ASPX_Proxyshell_Aug15 = "low"
+
+  strings:
+    $comment1 = " * Ported into LTP by Yang Xu <xuyang2018.jy@fujitsu.com>"
+    $comment2 = " * Proof-of-concept exploit for the Dirty Pipe"
+    $comment3 = " * vulnerability (CVE-2022-0847) caused by an uninitialized"
+    $comment4 = " * \" pipe_buffer.flags \" variable.  It demonstrates how to overwrite any"
+    $comment5 = " * Example: ./write_anything /root/.ssh/authorized_keys 1 $'\nssh-ed25519 AAA......\n'"
+    $comment6 = " * Further explanation: https://dirtypipe.cm4all.com/"
+
+  condition:
+    filesize < 8192 and all of them
+}

--- a/rules/false_positives/nmap.yara
+++ b/rules/false_positives/nmap.yara
@@ -13,3 +13,16 @@ rule nmap_fingerprints: override {
   condition:
     filesize < 512KB and $description and $license and #fingerprint > 0
 }
+
+rule nping_bin: override {
+  meta:
+    description               = "/usr/bin/nping"
+    SEKOIA_Tool_Nping_Strings = "low"
+
+  strings:
+    $nping = "Usage: nping [Probe mode] [Options] {target specification}"
+    $site  = "https://nmap.org/nping"
+
+  condition:
+    filesize < 1MB and all of them
+}

--- a/rules/impact/remote_access/py_setuptools.yara
+++ b/rules/impact/remote_access/py_setuptools.yara
@@ -106,8 +106,10 @@ rule setuptools_exec: medium {
   strings:
     $f_exec = /exec\([\"\'\/\w\,\.\ \-\)\(]{1,64}\)/ fullword
 
+    $not_hopper = "with open(\" hopper /__version__.py\") as fp:"
+
   condition:
-    remote_access_pythonSetup and any of ($f*)
+    remote_access_pythonSetup and any of ($f*) and none of ($not*)
 }
 
 rule setuptools_exec_high: high {

--- a/rules/impact/remote_access/reverse_shell.yara
+++ b/rules/impact/remote_access/reverse_shell.yara
@@ -56,10 +56,12 @@ rule perl_reverse_shell: critical {
     $redir_single = "'>&"
     $sh_i         = "sh -i"
 
-    $not_yarn1 = "If the package is not specified, Yarn will default to the current workspace."
-    $not_yarn2 = "yarn npm"
-    $not_yarn3 = "@yarnpkg"
-    $not_yarn4 = "YARN_"
+    $not_comment1 = "Upgrade all instances of lodash to the latest release, but ask confirmation for each"
+    $not_comment2 = "$0 up lodash -i"
+    $not_yarn1    = "If the package is not specified, Yarn will default to the current workspace."
+    $not_yarn2    = "yarn npm"
+    $not_yarn3    = "@yarnpkg"
+    $not_yarn4    = "YARN_"
 
   condition:
     $socket and $open and any of ($redir*) and $sh_i and none of ($not*)


### PR DESCRIPTION
This PR addresses several false positives.

The hardest rule to reconcile was `import_manipulator` which matches the legit PyPy `pickle.py` file as well as one of our malicious examples (`2024.pyobfuscated`). Simply adding a string to ignore the false positive comment reduces the criticality of the malicious sample since it also contains this string (and the rest of `pickle.py` most likely).

To get around this, I specifically ignored the sha256 hash of the good file.

The rest of the changes follow the usual `none of ($not*)` pattern.