### PR TITLE
Persist credentials for git commands

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ jobs:
           egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
       - name: Set up Octo-STS
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -36,8 +36,6 @@ jobs:
           apk update
           apk add bash curl findutils gh git go nodejs perl upx xz yara-x
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
       - name: Trust repository
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -27,8 +27,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
       - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
       - name: Set up Octo-STS
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0


### PR DESCRIPTION
For the time being, we need to persist credentials to run the `git` commands for the third-party, version, and release Workflows, otherwise, we get this error:
```
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```

This won't be a long-term revert but I don't want to leave things broken while I work on using the octo-sts token to handle auth for these commands.