### PR TITLE
Utilize more concurrency for nested extractions; apply golangci-lint fixes

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -153,4 +153,5 @@ jobs:
 
       - name: Run golangci-lint
         run: |
-          make golangci-lint-lint
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+          find "${GITHUB_WORKSPACE}" -name go.mod -execdir $(go env GOPATH)/bin/golangci-lint run -c "${GITHUB_WORKSPACE}/.golangci.yml" \;

--- a/pkg/action/diff.go
+++ b/pkg/action/diff.go
@@ -144,14 +144,14 @@ func relFileReport(ctx context.Context, c malcontent.Config, fromPath string, is
 				return true
 			}
 
-			rel, base, err := relPath(fromPath, fr, isArchive, isImage)
+			rel, b, err := relPath(fromPath, fr, isArchive, isImage)
 			if err != nil {
 				rangeErr = err
 				return false
 			}
 
 			fromRelPath[rel] = fr
-			base = base
+			base = b
 		}
 		return true
 	})
@@ -191,7 +191,7 @@ func scoreFile(fr, tr *malcontent.FileReport) bool {
 	return false
 }
 
-func Diff(ctx context.Context, c malcontent.Config, logger *clog.Logger) (*malcontent.Report, error) {
+func Diff(ctx context.Context, c malcontent.Config, _ *clog.Logger) (*malcontent.Report, error) {
 	if len(c.ScanPaths) != 2 {
 		return nil, fmt.Errorf("diff mode requires 2 paths, you passed in %d path(s)", len(c.ScanPaths))
 	}
@@ -371,7 +371,7 @@ func handleDir(ctx context.Context, c malcontent.Config, src, dest ScanResult, d
 	}
 }
 
-func handleFile(ctx context.Context, c malcontent.Config, fr, tr *malcontent.FileReport, relPath string, d *malcontent.DiffReport, src, dest ScanResult, isImage bool) {
+func handleFile(ctx context.Context, c malcontent.Config, fr, tr *malcontent.FileReport, relPath string, d *malcontent.DiffReport, _, dest ScanResult, isImage bool) {
 	// We've now established that file exists in both source & destination
 	if fr.RiskScore < c.MinFileRisk && tr.RiskScore < c.MinFileRisk {
 		clog.FromContext(ctx).Info("diff does not meet min trigger level", slog.Any("path", tr.Path))
@@ -466,7 +466,7 @@ func inferMoves(ctx context.Context, c malcontent.Config, d *malcontent.DiffRepo
 	}
 }
 
-func fileMove(ctx context.Context, c malcontent.Config, fr, tr *malcontent.FileReport, rpath, apath string, d *malcontent.DiffReport, score float64, src, dest ScanResult, isImage bool) {
+func fileMove(ctx context.Context, c malcontent.Config, fr, tr *malcontent.FileReport, rpath, apath string, d *malcontent.DiffReport, score float64, _, dest ScanResult, isImage bool) {
 	minRisk := int(math.Min(float64(c.MinRisk), float64(c.MinFileRisk)))
 	if fr.RiskScore < minRisk && tr.RiskScore < minRisk {
 		clog.FromContext(ctx).Info("diff does not meet min trigger level", slog.Any("path", tr.Path))

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -16,7 +16,7 @@ import (
 func ExtractGzip(ctx context.Context, d string, f string) error {
 	// Check whether the provided file is a valid gzip archive
 	var isGzip bool
-	if ft, err := programkind.GetCachedFileType(f); err == nil && ft != nil {
+	if ft, err := programkind.File(f); err == nil && ft != nil {
 		if ft.MIME == "application/gzip" {
 			isGzip = true
 		}

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -43,7 +43,7 @@ func ExtractTar(ctx context.Context, d string, f string) error {
 
 	isTGZ := strings.Contains(f, ".tar.gz") || strings.Contains(f, ".tgz")
 	var isGzip bool
-	if ft, err := programkind.GetCachedFileType(f); err == nil && ft != nil {
+	if ft, err := programkind.File(f); err == nil && ft != nil {
 		if ft.MIME == "application/gzip" {
 			isGzip = true
 		}

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/chainguard-dev/clog"
@@ -38,7 +37,7 @@ func ExtractZip(ctx context.Context, d string, f string) error {
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(runtime.GOMAXPROCS(0))
+	g.SetLimit(len(read.File))
 
 	for _, file := range read.File {
 		g.Go(func() error {

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -5,6 +5,7 @@ package malcontent
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"sync"
@@ -43,6 +44,7 @@ type Config struct {
 	ScanPaths             []string
 	Stats                 bool
 	TrimPrefixes          []string
+	ScannerPool           *ScannerPool
 }
 
 type Behavior struct {
@@ -141,4 +143,156 @@ type CombinedReport struct {
 	Removed   string
 	RemovedFR *FileReport
 	Score     float64
+}
+
+// ScannerPool manages a pool of yara-x scanners.
+type ScannerPool struct {
+	mu       sync.Mutex
+	scanners []*yarax.Scanner
+	rules    *yarax.Rules
+}
+
+// NewScannerPool creates a new scanner pool.
+func NewScannerPool(rules *yarax.Rules, count int) (*ScannerPool, error) {
+	if rules == nil {
+		return nil, fmt.Errorf("cannot create scanner pool: rules is nil")
+	}
+
+	if count < 0 {
+		return nil, fmt.Errorf("cannot create scanner pool: invalid count %d", count)
+	}
+
+	pool := &ScannerPool{
+		scanners: make([]*yarax.Scanner, 0, max(1, count)),
+		rules:    rules,
+	}
+
+	for i := range count {
+		scanner := yarax.NewScanner(rules)
+		if scanner == nil {
+			return nil, fmt.Errorf("failed to create scanner at index %d", i)
+		}
+		pool.scanners = append(pool.scanners, scanner)
+	}
+
+	return pool, nil
+}
+
+// Get returns a scanner from the pool or creates a new one if none are available.
+func (p *ScannerPool) Get() (*yarax.Scanner, error) {
+	if p == nil {
+		return nil, fmt.Errorf("scanner pool is nil")
+	}
+
+	if p.rules == nil {
+		return nil, fmt.Errorf("scanner pool has nil rules")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.scanners) == 0 {
+		scanner := yarax.NewScanner(p.rules)
+		if scanner == nil {
+			return nil, fmt.Errorf("failed to create new scanner")
+		}
+		return scanner, nil
+	}
+
+	lastIdx := len(p.scanners) - 1
+	scanner := p.scanners[lastIdx]
+	p.scanners = p.scanners[:lastIdx]
+
+	if scanner == nil {
+		scanner = yarax.NewScanner(p.rules)
+		if scanner == nil {
+			return nil, fmt.Errorf("failed to create replacement scanner for nil entry")
+		}
+	}
+
+	return scanner, nil
+}
+
+// Put returns a scanner to the pool.
+func (p *ScannerPool) Put(scanner *yarax.Scanner) error {
+	if p == nil {
+		return fmt.Errorf("scanner pool is nil")
+	}
+
+	if scanner == nil {
+		return fmt.Errorf("cannot put nil scanner into pool")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.scanners = append(p.scanners, scanner)
+	return nil
+}
+
+// Close cleans up the scanner pool.
+func (p *ScannerPool) Close() error {
+	if p == nil {
+		return fmt.Errorf("scanner pool is nil")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.scanners = nil
+	p.rules = nil
+
+	return nil
+}
+
+// InitScannerPool initializes a pool of yara-x scanners.
+func (c *Config) InitScannerPool() error {
+	if c == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	if c.ScannerPool != nil {
+		return nil
+	}
+
+	if c.Rules == nil {
+		return fmt.Errorf("cannot initialize scanner pool: Rules is nil")
+	}
+
+	concurrency := max(1, c.Concurrency)
+	var err error
+	c.ScannerPool, err = NewScannerPool(c.Rules, concurrency)
+	if err != nil {
+		return fmt.Errorf("failed to initialize scanner pool: %w", err)
+	}
+
+	return nil
+}
+
+// GetScanner returns a scanner from the pool.
+func (c *Config) GetScanner() (*yarax.Scanner, error) {
+	if c == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+
+	if c.ScannerPool == nil {
+		if err := c.InitScannerPool(); err != nil {
+			return nil, fmt.Errorf("failed to initialize scanner pool: %w", err)
+		}
+	}
+
+	return c.ScannerPool.Get()
+}
+
+// PutScanner returns a scanner to the pool.
+func (c *Config) PutScanner(scanner *yarax.Scanner) error {
+	if c == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	if c.ScannerPool == nil {
+		return fmt.Errorf("scanner pool is nil")
+	}
+
+	return c.ScannerPool.Put(scanner)
 }

--- a/pkg/programkind/programkind.go
+++ b/pkg/programkind/programkind.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/gabriel-vasile/mimetype"
 )
@@ -103,23 +102,6 @@ var supportedKind = map[string]string{
 type FileType struct {
 	Ext  string
 	MIME string
-}
-
-var fileTypeCache = sync.Map{}
-
-// GetCachedFileType returns previously-seen filetypes or stores novel filetypes for future retrieval
-func GetCachedFileType(path string) (*FileType, error) {
-	if ft, ok := fileTypeCache.Load(path); ok {
-		return ft.(*FileType), nil
-	}
-
-	ft, err := File(path)
-	if err != nil {
-		return nil, err
-	}
-
-	fileTypeCache.Store(path, ft)
-	return ft, nil
 }
 
 // IsSupportedArchive returns whether a path can be processed by our archive extractor.

--- a/pkg/render/tea.go
+++ b/pkg/render/tea.go
@@ -188,13 +188,13 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		case "up", "k":
-			m.viewport.LineUp(1)
+			m.viewport.ScrollUp(1)
 		case "down", "j":
-			m.viewport.LineDown(1)
+			m.viewport.ScrollDown(1)
 		case "pgup":
-			m.viewport.HalfViewUp()
+			m.viewport.HalfPageUp()
 		case "pgdown":
-			m.viewport.HalfViewDown()
+			m.viewport.HalfPageDown()
 		case "home":
 			m.viewport.GotoTop()
 		case "end":


### PR DESCRIPTION
In an effort to speed up large scans with many nested extractions, this PR leverages more concurrency in `ExtractZip` which will help with .`jar` files and also uses concurrency when extracting nested archives.

I experimented with streaming extractions and scans, but the performance benefit was not worth the complexity and was still worse than what this PR offers. This code shaved off about ~4-5 minutes from a local Trino scan (400 seconds versus 600-700).

I also re-added a simple scanner pool with a `sync.Pool`. The sweet spot is 1 scanner per CPU. For the concurrent extractions, there's a benefit in going higher than `c.Concurrency` so I opted to use the number of files from the extraction or the zip reader, respectively.

Finally, I made a few other tweaks based on a local `make golangci-lint-lint` run.