### PR TITLE
Immediately fail refreshes if UPX is not present

### DIFF
--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/malcontent/pkg/action"
 	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+	"github.com/chainguard-dev/malcontent/pkg/programkind"
 	"github.com/chainguard-dev/malcontent/pkg/render"
 	"github.com/chainguard-dev/malcontent/rules"
 	thirdparty "github.com/chainguard-dev/malcontent/third_party"
@@ -221,6 +222,10 @@ func executeRefresh(ctx context.Context, c Config, testData []TestData, logger *
 
 // Refresh updates all relevant test data in pkg/action and tests.
 func Refresh(ctx context.Context, rc Config, logger *clog.Logger) error {
+	// Check if UPX is present which is required for certain refreshes
+	if err := programkind.UPXInstalled(); err != nil {
+		return fmt.Errorf("required UPX installation not found: %w", err)
+	}
 	if rc.SamplesPath == "" {
 		return fmt.Errorf("sample location is required")
 	}


### PR DESCRIPTION
We need UPX to handle a few of our sample data refreshes/tests. If UPX isn't present, generated diffs will be incorrect. This PR immediately fails refreshes if UPX is not present.

Test:
```
$ brew uninstall upx
Uninstalling /opt/homebrew/Cellar/upx/4.2.4... (16 files, 2.4MB)
...
$ make out/mal
mkdir -p out
CGO_LDFLAGS="-L/Users/.../repos/chainguard-dev/malcontent/out/lib -Wl,-rpath,/Users/.../repos/chainguard-dev/malcontent/out/lib" \
        CGO_CPPFLAGS="-I/Users/.../repos/chainguard-dev/malcontent/out/include" \
        PKG_CONFIG_PATH="/Users/.../repos/chainguard-dev/malcontent/out/lib/pkgconfig" \
        go build -o out/mal ./cmd/mal
# github.com/chainguard-dev/malcontent/cmd/mal
...
./out/mal refresh
💣 required UPX installation not found: UPX executable not found in PATH
make: *** [refresh-sample-testdata] Error 2
```

If UPX is not present for normal scans, we'll still scan the packed binary.