### PR TITLE
Fix diff arg parsing, fix image extraction edge case

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -213,13 +213,13 @@ func main() {
 				}
 			}
 
-			// when diffing images, make sure the last two args are captured (the image URIs)
+			// when diffing, make sure the last two args are captured (packages or image URIs)
 			// when running refreshes, no flags will be passed
 			// when scanning, increment the slice index by one to account for flags by default
 			args := c.Args().Slice()
 			var scanPaths []string
 			switch {
-			case slices.Contains(args, "diff") && slices.Contains(args, "--image"):
+			case slices.Contains(args, "diff"):
 				scanPaths = args[len(args)-2:]
 			case slices.Contains(args, "refresh"):
 				scanPaths = args[1:]

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -107,6 +107,12 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	}
 	size := fi.Size()
 
+	if size == 0 {
+		fr := &malcontent.FileReport{Skipped: "zero-sized file", Path: path}
+		defer os.RemoveAll(path)
+		return fr, nil
+	}
+
 	fc := filePool.Get(size)
 	defer filePool.Put(fc)
 	if _, err := io.ReadFull(f, fc); err != nil {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -121,9 +121,6 @@ func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 
 	initializeOnce.Do(func() {
 		archivePool = pool.NewBufferPool()
-		// Create separate pools for frequently-extracted archive types
-		tarPool = pool.NewBufferPool()
-		zipPool = pool.NewBufferPool()
 	})
 
 	var extract func(context.Context, string, string) error

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -9,15 +9,25 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/malcontent/pkg/pool"
 	"golang.org/x/sync/errgroup"
+)
+
+var (
+	initZipPool sync.Once
 )
 
 // ExtractZip extracts .jar and .zip archives.
 func ExtractZip(ctx context.Context, d string, f string) error {
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting zip")
+
+	initZipPool.Do(func() {
+		zipPool = pool.NewBufferPool()
+	})
 
 	fi, err := os.Stat(f)
 	if err != nil {


### PR DESCRIPTION
This PR fixes an oversight from #837 where diff args were only correctly parsed when passing `--images`. We return the last two elements for all diffs (images, paths, files, etc.).

Additionally, this PR fixes a subtle bug with the sync pools when scanning images. The OCI method bypasses `ExtractArchiveToTempDir` so the pools were not being initialized and the scan would exit immediately. I also moved the zipPool initializtion to the `ExtractZip` function for consistency.