### PR TITLE
Fix golangci-lint-lint error propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(YARA_X_BIN):
 
 LINTERS += golangci-lint-lint
 golangci-lint-lint: $(GOLANGCI_LINT_BIN)
-	find . -maxdepth 1 -name go.mod -execdir "$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)" \;
+	find . -maxdepth 1 -name go.mod -print0 | xargs -0 -L1 -I{} /bin/sh -c '"$(GOLANGCI_LINT_BIN)" run -c "$(GOLANGCI_LINT_CONFIG)"' \;
 
 FIXERS += golangci-lint-fix
 golangci-lint-fix: $(GOLANGCI_LINT_BIN)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -52,7 +52,7 @@ func extractNestedArchive(ctx context.Context, d string, f string, extracted *sy
 	isArchive := false
 	ft, err := programkind.File(fullPath)
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to determine file type: %w", err)
 	}
 
 	switch {

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -19,9 +19,7 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-var (
-	initTarPool sync.Once
-)
+var initTarPool sync.Once
 
 // extractTar extracts .apk and .tar* archives.
 func ExtractTar(ctx context.Context, d string, f string) error {

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -16,9 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	initZipPool sync.Once
-)
+var initZipPool sync.Once
 
 // ExtractZip extracts .jar and .zip archives.
 func ExtractZip(ctx context.Context, d string, f string) error {


### PR DESCRIPTION
The `golangci-lint-lint` Make target wasn't propagating errors correctly, so CI would pass even with failures.

This PR uses `xargs` to ensure we fail Checks when there are findings.