### PR TITLE
Improve context handling universally

### DIFF
--- a/pkg/action/path.go
+++ b/pkg/action/path.go
@@ -12,6 +12,10 @@ import (
 
 // findFilesRecursively returns a list of files found recursively within a path.
 func findFilesRecursively(ctx context.Context, rootPath string) ([]string, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx)
 	var files []string
 

--- a/pkg/action/process.go
+++ b/pkg/action/process.go
@@ -23,6 +23,10 @@ type ProcessInfo struct {
 
 // ActiveProcesses is an exported function that a list of active processes.
 func ActiveProcesses(ctx context.Context) ([]*ProcessInfo, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	// Retrieve all of the active PIDs
 	procs, err := process.ProcessesWithContext(ctx)
 	if err != nil {

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -398,7 +398,7 @@ func processPaths(ctx context.Context, paths []string, scanInfo scanPathInfo, c 
 		cancel()
 	}()
 
-	g := setupErrorGroup(scanCtx, maxConcurrency)
+	g := setupErrorGroup(maxConcurrency)
 
 	setupMatchHandler(scanCtx, matchChan, c, cancel, logger)
 
@@ -416,10 +416,6 @@ func processPaths(ctx context.Context, paths []string, scanInfo scanPathInfo, c 
 	}()
 
 	for path := range pc {
-		if scanCtx.Err() != nil {
-			break
-		}
-
 		g.Go(func() error {
 			if scanCtx.Err() != nil {
 				return scanCtx.Err()
@@ -462,11 +458,7 @@ func createPathChannel(paths []string) chan string {
 	return pc
 }
 
-func setupErrorGroup(ctx context.Context, maxConcurrency int) *errgroup.Group {
-	if ctx.Err() != nil {
-		return nil
-	}
-
+func setupErrorGroup(maxConcurrency int) *errgroup.Group {
 	g := &errgroup.Group{}
 	g.SetLimit(maxConcurrency)
 	return g
@@ -666,7 +658,7 @@ func processArchive(ctx context.Context, c malcontent.Config, rfs []fs.FS, archi
 	scanCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	g := setupErrorGroup(ctx, maxConcurrency)
+	g := setupErrorGroup(maxConcurrency)
 
 	ep := createPathChannel(extractedPaths)
 	for path := range ep {

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -11,14 +11,12 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/malcontent/pkg/archive"
@@ -725,14 +723,6 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
 	scanCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-	go func() {
-		<-sigCh
-		cancel()
-	}()
 
 	r, err := recursiveScan(scanCtx, c)
 	if errors.Is(err, context.Canceled) {

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -11,12 +11,14 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/malcontent/pkg/archive"
@@ -49,6 +51,10 @@ var (
 
 // scanSinglePath YARA scans a single path and converts it to a fileReport.
 func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleFS []fs.FS, absPath string, archiveRoot string) (*malcontent.FileReport, error) {
+	if ctx.Err() != nil {
+		return &malcontent.FileReport{}, ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx)
 	logger = logger.With("path", path)
 
@@ -250,6 +256,10 @@ func exitIfHitOrMiss(frs *sync.Map, scanPath string, errIfHit bool, errIfMiss bo
 }
 
 func CachedRules(ctx context.Context, fss []fs.FS) (*yarax.Rules, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	if rules := compiledRuleCache.Load(); rules != nil {
 		return rules, nil
 	}
@@ -288,6 +298,10 @@ type scanPathInfo struct {
 
 // recursiveScan recursively YARA scans the configured paths - handling archives and OCI images.
 func recursiveScan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
+	if ctx.Err() != nil {
+		return &malcontent.Report{}, ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx)
 	r := initializeReport(c.IgnoreTags)
 	matchChan := make(chan matchResult, 1)
@@ -312,6 +326,10 @@ func initializeReport(ignoreTags []string) *malcontent.Report {
 }
 
 func handleScanPath(ctx context.Context, scanPath string, c malcontent.Config, r *malcontent.Report, matchChan chan matchResult, matchOnce *sync.Once, logger *clog.Logger) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if c.Renderer != nil {
 		c.Renderer.Scanning(ctx, scanPath)
 	}
@@ -338,6 +356,10 @@ func handleScanPath(ctx context.Context, scanPath string, c malcontent.Config, r
 }
 
 func prepareScanPath(ctx context.Context, scanPath string, isOCI bool, logger *clog.Logger) (scanPathInfo, error) {
+	if ctx.Err() != nil {
+		return scanPathInfo{}, ctx.Err()
+	}
+
 	info := scanPathInfo{
 		originalPath:  scanPath,
 		effectivePath: scanPath,
@@ -361,26 +383,63 @@ func prepareScanPath(ctx context.Context, scanPath string, isOCI bool, logger *c
 }
 
 func processPaths(ctx context.Context, paths []string, scanInfo scanPathInfo, c malcontent.Config, r *malcontent.Report, matchChan chan matchResult, matchOnce *sync.Once, logger *clog.Logger) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	maxConcurrency := getMaxConcurrency(c.Concurrency)
-	pc := createPathChannel(paths)
 
 	scanCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	g := setupErrorGroup(maxConcurrency)
+	go func() {
+		<-ctx.Done()
+		logger.Debug("parent context canceled, stopping scan")
+		cancel()
+	}()
+
+	g := setupErrorGroup(scanCtx, maxConcurrency)
+
 	setupMatchHandler(scanCtx, matchChan, c, cancel, logger)
 
+	pc := make(chan string, len(paths))
+	go func() {
+		defer close(pc)
+
+		for _, path := range paths {
+			select {
+			case <-scanCtx.Done():
+				return
+			case pc <- path:
+			}
+		}
+	}()
+
 	for path := range pc {
+		if scanCtx.Err() != nil {
+			break
+		}
+
 		g.Go(func() error {
+			if scanCtx.Err() != nil {
+				return scanCtx.Err()
+			}
 			return processPath(scanCtx, path, scanInfo, c, r, matchChan, matchOnce, logger)
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	err := g.Wait()
+
+	if scanCtx.Err() != nil && errors.Is(scanCtx.Err(), context.Canceled) {
+		logger.Debug("scan operation was canceled")
+		return scanCtx.Err()
+	}
+
+	if err != nil {
 		return handleScanError(matchChan, r, c, err)
 	}
 
-	if c.OCI {
+	if c.OCI && ctx.Err() == nil {
 		return handleOCIResults(ctx, scanInfo.imageURI, &r.Files, c, logger)
 	}
 
@@ -403,13 +462,21 @@ func createPathChannel(paths []string) chan string {
 	return pc
 }
 
-func setupErrorGroup(maxConcurrency int) *errgroup.Group {
+func setupErrorGroup(ctx context.Context, maxConcurrency int) *errgroup.Group {
+	if ctx.Err() != nil {
+		return nil
+	}
+
 	g := &errgroup.Group{}
 	g.SetLimit(maxConcurrency)
 	return g
 }
 
 func setupMatchHandler(ctx context.Context, matchChan chan matchResult, c malcontent.Config, cancel context.CancelFunc, logger *clog.Logger) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	go func() {
 		select {
 		case match := <-matchChan:
@@ -426,6 +493,9 @@ func setupMatchHandler(ctx context.Context, matchChan chan matchResult, c malcon
 }
 
 func processPath(ctx context.Context, path string, scanInfo scanPathInfo, c malcontent.Config, r *malcontent.Report, matchChan chan matchResult, matchOnce *sync.Once, logger *clog.Logger) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -438,6 +508,10 @@ func processPath(ctx context.Context, path string, scanInfo scanPathInfo, c malc
 }
 
 func handleArchiveFile(ctx context.Context, path string, c malcontent.Config, r *malcontent.Report, matchChan chan matchResult, matchOnce *sync.Once, logger *clog.Logger) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	frs, err := processArchive(ctx, c, c.RuleFS, path, logger)
 	if err != nil {
 		logger.Errorf("unable to process %s: %v", path, err)
@@ -457,6 +531,9 @@ func handleArchiveFile(ctx context.Context, path string, c malcontent.Config, r 
 	//nolint:nestif // ignore complexity of 14
 	if frs != nil {
 		frs.Range(func(key, value any) bool {
+			if ctx.Err() != nil {
+				return false
+			}
 			if key == nil || value == nil {
 				return true
 			}
@@ -586,12 +663,15 @@ func processArchive(ctx context.Context, c malcontent.Config, rfs []fs.FS, archi
 	}
 
 	maxConcurrency := getMaxConcurrency(c.Concurrency)
-	g := setupErrorGroup(maxConcurrency)
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	g := setupErrorGroup(ctx, maxConcurrency)
 
 	ep := createPathChannel(extractedPaths)
 	for path := range ep {
 		g.Go(func() error {
-			fr, err := processFile(ctx, c, rfs, path, archivePath, tmpRoot, logger)
+			fr, err := processFile(scanCtx, c, rfs, path, archivePath, tmpRoot, logger)
 			if err != nil {
 				return err
 			}
@@ -651,11 +731,29 @@ func processFile(ctx context.Context, c malcontent.Config, ruleFS []fs.FS, path 
 
 // Scan YARA scans a data source, applying output filters if necessary.
 func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) {
-	r, err := recursiveScan(ctx, c)
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	r, err := recursiveScan(scanCtx, c)
+	if errors.Is(err, context.Canceled) {
+		return r, fmt.Errorf("scan operation cancelled: %w", err)
+	}
 	if err != nil && !interactive(c) {
 		return r, err
 	}
+
 	r.Files.Range(func(key, value any) bool {
+		if scanCtx.Err() != nil {
+			return false
+		}
 		if key == nil || value == nil {
 			return true
 		}
@@ -666,7 +764,7 @@ func Scan(ctx context.Context, c malcontent.Config) (*malcontent.Report, error) 
 		}
 		return true
 	})
-	if c.Stats && c.Renderer.Name() != "JSON" && c.Renderer.Name() != "YAML" {
+	if scanCtx.Err() != nil && c.Stats && c.Renderer.Name() != "JSON" && c.Renderer.Name() != "YAML" {
 		err = render.Statistics(&c, r)
 		if err != nil {
 			return r, fmt.Errorf("stats: %w", err)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -133,7 +133,7 @@ func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 	go func() {
 		<-ctx.Done()
 		logger.Debug("context cancelled, cleaning up temp dir")
-		defer os.RemoveAll(tmpDir)
+		os.RemoveAll(tmpDir)
 	}()
 
 	initializeOnce.Do(func() {
@@ -221,11 +221,6 @@ func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 		}
 		return true
 	})
-
-	if ctx.Err() != nil {
-		defer os.RemoveAll(tmpDir)
-		return "", ctx.Err()
-	}
 
 	return tmpDir, nil
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -31,6 +31,10 @@ func IsValidPath(target, dir string) bool {
 }
 
 func extractNestedArchive(ctx context.Context, d string, f string, extracted *sync.Map) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	fullPath := filepath.Join(d, f)
 
 	fi, err := os.Stat(fullPath)
@@ -99,6 +103,9 @@ func extractNestedArchive(ctx context.Context, d string, f string, extracted *sy
 	}
 
 	for _, file := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		rel := file.Name()
 		if _, alreadyProcessed := extracted.Load(rel); !alreadyProcessed {
 			if err := extractNestedArchive(ctx, d, rel, extracted); err != nil {
@@ -111,6 +118,10 @@ func extractNestedArchive(ctx context.Context, d string, f string, extracted *sy
 
 // extractArchiveToTempDir creates a temporary directory and extracts the archive file for scanning.
 func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("path", path)
 	logger.Debug("creating temp dir")
 
@@ -118,6 +129,12 @@ func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
+
+	go func() {
+		<-ctx.Done()
+		logger.Debug("context cancelled, cleaning up temp dir")
+		defer os.RemoveAll(tmpDir)
+	}()
 
 	initializeOnce.Do(func() {
 		archivePool = pool.NewBufferPool()
@@ -204,6 +221,11 @@ func ExtractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 		}
 		return true
 	})
+
+	if ctx.Err() != nil {
+		defer os.RemoveAll(tmpDir)
+		return "", ctx.Err()
+	}
 
 	return tmpDir, nil
 }

--- a/pkg/archive/bz2.go
+++ b/pkg/archive/bz2.go
@@ -14,6 +14,10 @@ import (
 
 // Extract Bz2 extracts bzip2 files.
 func ExtractBz2(ctx context.Context, d, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting bzip2 file")
 

--- a/pkg/archive/deb.go
+++ b/pkg/archive/deb.go
@@ -16,6 +16,10 @@ import (
 
 // ExtractDeb extracts .deb packages.
 func ExtractDeb(ctx context.Context, d, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting deb")
 

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -14,6 +14,10 @@ import (
 
 // extractGzip extracts .gz archives.
 func ExtractGzip(ctx context.Context, d string, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Check whether the provided file is a valid gzip archive
 	var isGzip bool
 	if ft, err := programkind.File(f); err == nil && ft != nil {

--- a/pkg/archive/oci.go
+++ b/pkg/archive/oci.go
@@ -13,6 +13,10 @@ import (
 )
 
 func prepareImage(ctx context.Context, d string) (string, *os.File, error) {
+	if ctx.Err() != nil {
+		return "", nil, ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("image", d)
 	logger.Debug("preparing image")
 	tmpDir, err := os.MkdirTemp("", filepath.Base(d))

--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -19,6 +19,10 @@ import (
 
 // extractRPM extracts .rpm packages.
 func ExtractRPM(ctx context.Context, d, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting rpm")
 

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -23,6 +23,10 @@ var initTarPool sync.Once
 
 // extractTar extracts .apk and .tar* archives.
 func ExtractTar(ctx context.Context, d string, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting tar")
 

--- a/pkg/archive/upx.go
+++ b/pkg/archive/upx.go
@@ -13,6 +13,10 @@ import (
 )
 
 func ExtractUPX(ctx context.Context, d, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Check if UPX is installed
 	if err := programkind.UPXInstalled(); err != nil {
 		return err

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -20,6 +20,10 @@ var initZipPool sync.Once
 
 // ExtractZip extracts .jar and .zip archives.
 func ExtractZip(ctx context.Context, d string, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting zip")
 
@@ -61,6 +65,10 @@ func ExtractZip(ctx context.Context, d string, f string) error {
 }
 
 func extractFile(ctx context.Context, file *zip.File, destDir string, logger *clog.Logger) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// #nosec G115 // ignore Type conversion which leads to integer overflow
 	buf := zipPool.Get(int64(file.UncompressedSize64))
 	defer zipPool.Put(buf)

--- a/pkg/archive/zlib.go
+++ b/pkg/archive/zlib.go
@@ -13,6 +13,10 @@ import (
 
 // extractZlib extracts extension-agnostic zlib-compressed files.
 func ExtractZlib(ctx context.Context, d string, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debugf("extracting zlib")
 

--- a/pkg/archive/zstd.go
+++ b/pkg/archive/zstd.go
@@ -14,6 +14,10 @@ import (
 
 // ExtractZstd extracts .zst and .zstd archives.
 func ExtractZstd(ctx context.Context, d string, f string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	logger := clog.FromContext(ctx).With("dir", d, "file", f)
 	logger.Debug("extracting zstd")
 

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -160,6 +160,10 @@ func removeRules(data []byte, rulesToRemove []string) []byte {
 }
 
 func Recursive(ctx context.Context, fss []fs.FS) (*yarax.Rules, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	yxc, err := yarax.NewCompiler(yarax.ConditionOptimization(true))
 	if err != nil {
 		return nil, fmt.Errorf("yarax compiler: %w", err)

--- a/pkg/refresh/action.go
+++ b/pkg/refresh/action.go
@@ -36,6 +36,10 @@ var actionTestData = []actionData{
 }
 
 func actionRefresh(ctx context.Context) ([]TestData, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	testData := make([]TestData, 0, len(actionTestData))
 
 	for _, td := range actionTestData {

--- a/pkg/refresh/diff.go
+++ b/pkg/refresh/diff.go
@@ -148,6 +148,10 @@ var diffTestData = []diffData{
 }
 
 func diffRefresh(ctx context.Context, rc Config) ([]TestData, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	testData := make([]TestData, 0, len(diffTestData))
 
 	for _, td := range diffTestData {

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -28,7 +28,11 @@ func (r JSON) File(_ context.Context, _ *malcontent.FileReport) error {
 	return nil
 }
 
-func (r JSON) Full(_ context.Context, c *malcontent.Config, rep *malcontent.Report) error {
+func (r JSON) Full(ctx context.Context, c *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	jr := Report{
 		Diff:   rep.Diff,
 		Files:  make(map[string]*malcontent.FileReport),
@@ -36,6 +40,10 @@ func (r JSON) Full(_ context.Context, c *malcontent.Config, rep *malcontent.Repo
 	}
 
 	rep.Files.Range(func(key, value any) bool {
+		if ctx.Err() != nil {
+			return false
+		}
+
 		if key == nil || value == nil {
 			return true
 		}

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -60,6 +60,10 @@ func (r Markdown) File(ctx context.Context, fr *malcontent.FileReport) error {
 }
 
 func (r Markdown) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if rep.Diff == nil {
 		return nil
 	}
@@ -153,8 +157,8 @@ func (r Markdown) Full(ctx context.Context, _ *malcontent.Config, rep *malconten
 	return nil
 }
 
-func markdownTable(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
-	if fr.Skipped != "" {
+func markdownTable(ctx context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
+	if ctx.Err() != nil || fr.Skipped != "" {
 		return
 	}
 

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -25,7 +25,11 @@ func (r Simple) Name() string { return "Simple" }
 
 func (r Simple) Scanning(_ context.Context, _ string) {}
 
-func (r Simple) File(_ context.Context, fr *malcontent.FileReport) error {
+func (r Simple) File(ctx context.Context, fr *malcontent.FileReport) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if fr.Skipped != "" {
 		return nil
 	}
@@ -48,7 +52,11 @@ func (r Simple) File(_ context.Context, fr *malcontent.FileReport) error {
 	return nil
 }
 
-func (r Simple) Full(_ context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+func (r Simple) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if rep.Diff == nil {
 		return nil
 	}

--- a/pkg/render/strings.go
+++ b/pkg/render/strings.go
@@ -79,7 +79,11 @@ func (r StringMatches) Scanning(_ context.Context, path string) {
 	fmt.Fprintf(r.w, "🔎 Scanning %q\n", path)
 }
 
-func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error {
+func (r StringMatches) File(ctx context.Context, fr *malcontent.FileReport) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if fr.Skipped != "" || len(fr.Behaviors) == 0 {
 		return nil
 	}
@@ -109,7 +113,11 @@ func (r StringMatches) File(_ context.Context, fr *malcontent.FileReport) error 
 	return nil
 }
 
-func (r StringMatches) Full(_ context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+func (r StringMatches) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Non-diff files are handled on the fly by File()
 	if rep.Diff == nil {
 		return nil

--- a/pkg/render/tea.go
+++ b/pkg/render/tea.go
@@ -347,13 +347,21 @@ func (r *Interactive) Start() {
 	}()
 }
 
-func (r *Interactive) Scanning(_ context.Context, path string) {
+func (r *Interactive) Scanning(ctx context.Context, path string) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.program.Send(scanUpdateMsg{path: path})
 }
 
 func (r *Interactive) File(ctx context.Context, fr *malcontent.FileReport) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -384,6 +392,10 @@ func (r *Interactive) File(ctx context.Context, fr *malcontent.FileReport) error
 }
 
 func (r *Interactive) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	defer func() {
 		r.program.Send(scanCompleteMsg{})
 		r.wg.Wait()

--- a/pkg/render/tea_style.go
+++ b/pkg/render/tea_style.go
@@ -121,8 +121,8 @@ func wrapLine(text string, width int) string {
 	return result.String()
 }
 
-func renderFileSummaryTea(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
-	if fr.Skipped != "" {
+func renderFileSummaryTea(ctx context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
+	if ctx.Err() != nil || fr.Skipped != "" {
 		return
 	}
 

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -82,6 +82,10 @@ func (r Terminal) Scanning(_ context.Context, path string) {
 }
 
 func (r Terminal) File(ctx context.Context, fr *malcontent.FileReport) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if fr.Skipped == "" && len(fr.Behaviors) > 0 {
 		renderFileSummary(ctx, fr, r.w,
 			tableConfig{
@@ -93,6 +97,10 @@ func (r Terminal) File(ctx context.Context, fr *malcontent.FileReport) error {
 }
 
 func (r Terminal) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Non-diff files are handled on the fly by File()
 	if rep.Diff == nil {
 		return nil
@@ -216,7 +224,11 @@ func ansiLineLength(s string) int {
 	return len(clean)
 }
 
-func renderFileSummary(_ context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
+func renderFileSummary(ctx context.Context, fr *malcontent.FileReport, w io.Writer, rc tableConfig) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	width := suggestedWidth()
 
 	byNamespace := map[string][]*malcontent.Behavior{}

--- a/pkg/render/terminal_brief.go
+++ b/pkg/render/terminal_brief.go
@@ -34,7 +34,11 @@ func (r TerminalBrief) Scanning(_ context.Context, path string) {
 	fmt.Fprintf(r.w, "🔎 Scanning %q\n", path)
 }
 
-func (r TerminalBrief) File(_ context.Context, fr *malcontent.FileReport) error {
+func (r TerminalBrief) File(ctx context.Context, fr *malcontent.FileReport) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if fr.Skipped != "" || len(fr.Behaviors) == 0 {
 		return nil
 	}
@@ -69,7 +73,11 @@ func (r TerminalBrief) File(_ context.Context, fr *malcontent.FileReport) error 
 	return nil
 }
 
-func (r TerminalBrief) Full(_ context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+func (r TerminalBrief) Full(ctx context.Context, _ *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Non-diff files are handled on the fly by File()
 	if rep.Diff == nil {
 		return nil

--- a/pkg/render/yaml.go
+++ b/pkg/render/yaml.go
@@ -28,7 +28,11 @@ func (r YAML) File(_ context.Context, _ *malcontent.FileReport) error {
 	return nil
 }
 
-func (r YAML) Full(_ context.Context, c *malcontent.Config, rep *malcontent.Report) error {
+func (r YAML) Full(ctx context.Context, c *malcontent.Config, rep *malcontent.Report) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// Make the sync.Map YAML-friendly
 	yr := Report{
 		Diff:   rep.Diff,
@@ -37,6 +41,9 @@ func (r YAML) Full(_ context.Context, c *malcontent.Config, rep *malcontent.Repo
 	}
 
 	rep.Files.Range(func(key, value any) bool {
+		if ctx.Err() != nil {
+			return false
+		}
 		if key == nil || value == nil {
 			return true
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -639,10 +639,6 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 
 // upgradeRisk determines whether to upgrade risk based on finding density.
 func upgradeRisk(ctx context.Context, riskScore int, riskCounts map[int]int, size int64) bool {
-	if ctx.Err() != nil {
-		return false
-	}
-
 	if riskScore != 3 {
 		return false
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -366,6 +366,10 @@ func TrimPrefixes(path string, prefixes []string) string {
 
 //nolint:cyclop // ignore complexity of 64
 func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte) (*malcontent.FileReport, error) {
+	if ctx.Err() != nil {
+		return &malcontent.FileReport{}, ctx.Err()
+	}
+
 	if mrs == nil {
 		return nil, fmt.Errorf("scan failed")
 	}
@@ -635,6 +639,10 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 
 // upgradeRisk determines whether to upgrade risk based on finding density.
 func upgradeRisk(ctx context.Context, riskScore int, riskCounts map[int]int, size int64) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
 	if riskScore != 3 {
 		return false
 	}


### PR DESCRIPTION
I noticed that we spew stack traces when scans are interrupted/canceled/etc. in Cloud Run which is not ideal. I don't think we have any panics occurring, but this PR improves context handling so that we propagate errors/cancellations correctly instead of continuing to attempt scans/extractions/etc.

@wlynch -- let me know if you think there are any other improvements we can make!