### PR TITLE
Use language-specific filter rules to reduce false-positives

### DIFF
--- a/rules/anti-static/obfuscation/js.yara
+++ b/rules/anti-static/obfuscation/js.yara
@@ -2,25 +2,32 @@ import "math"
 
 private rule obfs_probably_js {
   strings:
-    $f_function  = /function\(\w{0,8}\)/
-    $f_const     = /\bconst\s/
-    $f_return    = /\breturn\s/
-    $f_var       = /\bvar\s/
     $f_Array     = "Array.prototype" fullword
-    $f_true      = "true);"
-    $f_false     = "false);"
-    $f_run       = ".run("
-    $f_Run       = ".Run("
-    $f_Object    = "Object."
     $f_async     = "async function"
     $f_await     = "await"
-    $f_this      = "this."
+    $f_catch     = "} catch"
+    $f_const     = /\bconst\s/
+    $f_false     = "false);"
+    $f_function  = /function\(\w{0,32}\)/
+    $f_function2 = "function()"
+    $f_Object    = "Object."
+    $f_promise   = "Promise"
     $f_prototype = ".prototype"
+    $f_require   = "require("
+    $f_return    = /\breturn\s/
+    $f_Run       = ".Run("
+    $f_run       = ".run("
+    $f_strict    = "==="
+    $f_this      = "this."
+    $f_this2     = "this["
+    $f_true      = "true);"
+    $f_try       = "try {"
+    $f_var       = /\bvar\s/
 
     $not_asyncio = "await asyncio"
 
   condition:
-    filesize < 5MB and 3 of them and none of ($not*)
+    filesize < 5MB and 4 of them and none of ($not*)
 }
 
 rule character_obfuscation: medium {

--- a/rules/anti-static/obfuscation/reverse.yara
+++ b/rules/anti-static/obfuscation/reverse.yara
@@ -1,3 +1,26 @@
+private rule reverse_probably_js {
+  strings:
+    $f_function  = /function\(\w{0,8}\)/
+    $f_const     = /\bconst\s/
+    $f_return    = /\breturn\s/
+    $f_var       = /\bvar\s/
+    $f_Array     = "Array.prototype" fullword
+    $f_true      = "true);"
+    $f_false     = "false);"
+    $f_run       = ".run("
+    $f_Run       = ".Run("
+    $f_Object    = "Object."
+    $f_async     = "async function"
+    $f_await     = "await"
+    $f_this      = "this."
+    $f_prototype = ".prototype"
+
+    $not_asyncio = "await asyncio"
+
+  condition:
+    filesize < 3MB and 3 of them and none of ($not*)
+}
+
 rule string_reversal: medium {
   meta:
     description = "reverses strings"
@@ -29,5 +52,5 @@ rule js_reversal: critical {
     $ref2 = /n.{0,3}r.{0,3}u.{0,3}t.{0,3}e.{0,3}r/
 
   condition:
-    filesize < 1MB and all of them
+    reverse_probably_js and filesize < 1MB and all of them
 }

--- a/rules/anti-static/obfuscation/reverse.yara
+++ b/rules/anti-static/obfuscation/reverse.yara
@@ -1,24 +1,31 @@
 private rule reverse_probably_js {
   strings:
-    $f_function  = /function\(\w{0,8}\)/
-    $f_const     = /\bconst\s/
-    $f_return    = /\breturn\s/
-    $f_var       = /\bvar\s/
     $f_Array     = "Array.prototype" fullword
-    $f_true      = "true);"
-    $f_false     = "false);"
-    $f_run       = ".run("
-    $f_Run       = ".Run("
-    $f_Object    = "Object."
     $f_async     = "async function"
     $f_await     = "await"
-    $f_this      = "this."
+    $f_catch     = "} catch"
+    $f_const     = /\bconst\s/
+    $f_false     = "false);"
+    $f_function  = /function\(\w{0,32}\)/
+    $f_function2 = "function()"
+    $f_Object    = "Object."
+    $f_promise   = "Promise"
     $f_prototype = ".prototype"
+    $f_require   = "require("
+    $f_return    = /\breturn\s/
+    $f_Run       = ".Run("
+    $f_run       = ".run("
+    $f_strict    = "==="
+    $f_this      = "this."
+    $f_this2     = "this["
+    $f_true      = "true);"
+    $f_try       = "try {"
+    $f_var       = /\bvar\s/
 
     $not_asyncio = "await asyncio"
 
   condition:
-    filesize < 3MB and 3 of them and none of ($not*)
+    filesize < 5MB and 4 of them and none of ($not*)
 }
 
 rule string_reversal: medium {

--- a/rules/exec/remote_commands/code_eval.yara
+++ b/rules/exec/remote_commands/code_eval.yara
@@ -2,25 +2,32 @@ import "math"
 
 private rule eval_probably_js {
   strings:
-    $f_function  = /function\(\w{0,8}\)/
-    $f_const     = /\bconst\s/
-    $f_return    = /\breturn\s/
-    $f_var       = /\bvar\s/
     $f_Array     = "Array.prototype" fullword
-    $f_true      = "true);"
-    $f_false     = "false);"
-    $f_run       = ".run("
-    $f_Run       = ".Run("
-    $f_Object    = "Object."
     $f_async     = "async function"
     $f_await     = "await"
-    $f_this      = "this."
+    $f_catch     = "} catch"
+    $f_const     = /\bconst\s/
+    $f_false     = "false);"
+    $f_function  = /function\(\w{0,32}\)/
+    $f_function2 = "function()"
+    $f_Object    = "Object."
+    $f_promise   = "Promise"
     $f_prototype = ".prototype"
+    $f_require   = "require("
+    $f_return    = /\breturn\s/
+    $f_Run       = ".Run("
+    $f_run       = ".run("
+    $f_strict    = "==="
+    $f_this      = "this."
+    $f_this2     = "this["
+    $f_true      = "true);"
+    $f_try       = "try {"
+    $f_var       = /\bvar\s/
 
     $not_asyncio = "await asyncio"
 
   condition:
-    filesize < 5MB and 3 of them and none of ($not*)
+    filesize < 5MB and 4 of them and none of ($not*)
 }
 
 private rule eval_probably_python {

--- a/rules/exec/remote_commands/code_eval.yara
+++ b/rules/exec/remote_commands/code_eval.yara
@@ -1,5 +1,43 @@
 import "math"
 
+private rule eval_probably_js {
+  strings:
+    $f_function  = /function\(\w{0,8}\)/
+    $f_const     = /\bconst\s/
+    $f_return    = /\breturn\s/
+    $f_var       = /\bvar\s/
+    $f_Array     = "Array.prototype" fullword
+    $f_true      = "true);"
+    $f_false     = "false);"
+    $f_run       = ".run("
+    $f_Run       = ".Run("
+    $f_Object    = "Object."
+    $f_async     = "async function"
+    $f_await     = "await"
+    $f_this      = "this."
+    $f_prototype = ".prototype"
+
+    $not_asyncio = "await asyncio"
+
+  condition:
+    filesize < 5MB and 3 of them and none of ($not*)
+}
+
+private rule eval_probably_python {
+  strings:
+    $import       = "import "
+    $f_common     = /\s(def|if|with|else|try|except:) /
+    $f_exotic     = /exec\(|b64decode|bytes\(/
+    $f_for        = /for [a-z] in/
+    $f_join       = ".join("
+    $f_requests   = /(from|import) requests/
+    $f_requests2  = "requests."
+    $f_subprocess = /subprocess.(Popen|run)/
+
+  condition:
+    filesize < 10MB and ($import in (1..1024) or any of ($f*))
+}
+
 rule js_eval: medium {
   meta:
     description = "evaluate code dynamically using eval()"
@@ -10,7 +48,7 @@ rule js_eval: medium {
     $not_empty = "eval()"
 
   condition:
-    filesize < 1MB and any of ($val*) and none of ($not*)
+    eval_probably_js and filesize < 1MB and any of ($val*) and none of ($not*)
 }
 
 rule js_eval_fx_str: high {
@@ -21,7 +59,7 @@ rule js_eval_fx_str: high {
     $val = /eval\(\w{0,16}\([\"\'].{0,16}/
 
   condition:
-    filesize < 1MB and any of ($val*)
+    eval_probably_js and filesize < 1MB and any of ($val*)
 }
 
 rule js_eval_fx_str_multiple: critical {
@@ -32,7 +70,7 @@ rule js_eval_fx_str_multiple: critical {
     $val = /eval\(\w{0,16}\([\"\'].{0,16}/
 
   condition:
-    filesize < 1MB and #val > 1
+    eval_probably_js and filesize < 1MB and #val > 1
 }
 
 rule js_eval_response: critical {
@@ -43,7 +81,7 @@ rule js_eval_response: critical {
     $val = /eval\(\w{0,16}\.responseText\)/
 
   condition:
-    filesize < 1MB and any of ($val*)
+    eval_probably_js and filesize < 1MB and any of ($val*)
 }
 
 rule js_eval_near_enough_fromChar: high {
@@ -55,7 +93,7 @@ rule js_eval_near_enough_fromChar: high {
     $decrypt = "String.fromCharCode"
 
   condition:
-    filesize < 5MB and all of them and math.abs(@exec - @decrypt) > 384
+    eval_probably_js and filesize < 5MB and all of them and math.abs(@exec - @decrypt) > 384
 }
 
 rule js_eval_obfuscated_fromChar: critical {
@@ -67,7 +105,7 @@ rule js_eval_obfuscated_fromChar: critical {
     $ref  = /fromCharCode\(\w{0,16}\s{0,2}[\-\+\*\^]{0,2}\w{0,16}/
 
   condition:
-    filesize < 5MB and all of them and math.abs(@exec - @ref) > 384
+    eval_probably_js and filesize < 5MB and all of them and math.abs(@exec - @ref) > 384
 }
 
 rule python_exec: medium {
@@ -84,7 +122,7 @@ rule python_exec: medium {
     $empty    = "exec()"
 
   condition:
-    filesize < 1MB and any of ($f*) and $val and not $empty
+    eval_probably_python and filesize < 1MB and any of ($f*) and $val and not $empty
 }
 
 rule python_exec_near_enough_chr: high {
@@ -96,7 +134,7 @@ rule python_exec_near_enough_chr: high {
     $chr  = "chr("
 
   condition:
-    all of them and math.abs(@chr - @exec) < 768
+    eval_probably_python and all of them and math.abs(@chr - @exec) < 768
 }
 
 rule python_exec_near_enough_fernet: high {
@@ -108,7 +146,7 @@ rule python_exec_near_enough_fernet: high {
     $fernet = "Fernet("
 
   condition:
-    all of them and math.abs(@exec - @fernet) < 768
+    eval_probably_python and all of them and math.abs(@exec - @fernet) < 768
 }
 
 rule python_exec_near_enough_decrypt: high {
@@ -120,7 +158,7 @@ rule python_exec_near_enough_decrypt: high {
     $decrypt = "decrypt("
 
   condition:
-    all of them and math.abs(@exec - @decrypt) < 768
+    eval_probably_python and all of them and math.abs(@exec - @decrypt) < 768
 }
 
 rule python_exec_chr: critical {
@@ -131,7 +169,7 @@ rule python_exec_chr: critical {
     $exec = /exec\(.{0,16}chr\(.{0,16}\[\d[\d\, ]{0,64}/
 
   condition:
-    filesize < 512KB and all of them
+    eval_probably_python and filesize < 512KB and all of them
 }
 
 rule python_exec_bytes: critical {
@@ -142,7 +180,7 @@ rule python_exec_bytes: critical {
     $exec = /exec\([\w\.\(]{0,16}\(b['"].{8,16}/
 
   condition:
-    filesize < 512KB and all of them
+    eval_probably_python and filesize < 512KB and all of them
 }
 
 rule python_exec_complex: high {
@@ -156,7 +194,7 @@ rule python_exec_complex: high {
     $not_versioneer = "exec(VERSIONEER.decode(), globals())"
 
   condition:
-    filesize < 512KB and $exec and none of ($not*)
+    eval_probably_python and filesize < 512KB and $exec and none of ($not*)
 }
 
 rule python_exec_fernet: critical {
@@ -167,7 +205,7 @@ rule python_exec_fernet: critical {
     $exec = /exec\(.{0,16}Fernet\(.{0,64}/
 
   condition:
-    filesize < 512KB and all of them
+    eval_probably_python and filesize < 512KB and all of them
 }
 
 rule shell_eval: medium {

--- a/tests/javascript/2024.xmlrpc/validator.js.simple
+++ b/tests/javascript/2024.xmlrpc/validator.js.simple
@@ -2,7 +2,6 @@
 anti-static/obfuscation/bool: medium
 anti-static/obfuscation/hex: medium
 anti-static/obfuscation/js: critical
-anti-static/obfuscation/python: critical
 anti-static/obfuscation/strtoi: medium
 c2/addr/url: medium
 c2/client: medium

--- a/tests/linux/2024.melofee/pskt.simple
+++ b/tests/linux/2024.melofee/pskt.simple
@@ -5,6 +5,7 @@ anti-behavior/LD_PROFILE: medium
 anti-behavior/random_behavior: low
 anti-static/elf/entropy: high
 anti-static/elf/multiple: medium
+anti-static/obfuscation/js: medium
 c2/addr/ip: medium
 c2/addr/url: low
 c2/tool_transfer/arch: low

--- a/tests/linux/clean/botan.simple
+++ b/tests/linux/clean/botan.simple
@@ -1,5 +1,6 @@
 # linux/clean/botan: medium
 anti-behavior/random_behavior: low
+anti-static/obfuscation/js: medium
 credential/password: low
 credential/ssl/private_key: low
 crypto/aes: low

--- a/tests/linux/clean/botan.simple
+++ b/tests/linux/clean/botan.simple
@@ -1,6 +1,5 @@
 # linux/clean/botan: medium
 anti-behavior/random_behavior: low
-anti-static/obfuscation/js: medium
 credential/password: low
 credential/ssl/private_key: low
 crypto/aes: low

--- a/tests/linux/clean/x11vnc.simple
+++ b/tests/linux/clean/x11vnc.simple
@@ -1,5 +1,6 @@
 # linux/clean/x11vnc: medium
 anti-behavior/random_behavior: low
+anti-static/obfuscation/js: medium
 c2/addr/http_dynamic: medium
 c2/addr/ip: medium
 c2/addr/url: low

--- a/tests/npm/2024.testerrrrrrrrrr/init.js.simple
+++ b/tests/npm/2024.testerrrrrrrrrr/init.js.simple
@@ -2,7 +2,6 @@
 anti-static/obfuscation/bool: medium
 anti-static/obfuscation/hex: medium
 anti-static/obfuscation/js: critical
-anti-static/obfuscation/python: critical
 anti-static/obfuscation/url: critical
 c2/addr/server: medium
 c2/addr/url: medium

--- a/tests/php/2024.S3RV4N7-SHELL/crot.php.simple
+++ b/tests/php/2024.S3RV4N7-SHELL/crot.php.simple
@@ -5,6 +5,5 @@ anti-static/obfuscation/php: medium
 data/base64/decode: medium
 data/encoding/base64: low
 evasion/indicator_blocking/mask_exceptions: medium
-exec/remote_commands/code_eval: medium
 impact/remote_access/php: high
 net/url/embedded: low

--- a/tests/php/2024.sagsooz/bestmini.php.simple
+++ b/tests/php/2024.sagsooz/bestmini.php.simple
@@ -3,6 +3,5 @@
 3P/sig_base/webshell_php_by: critical
 3P/sig_base/webshell_php_strings: critical
 anti-static/obfuscation/php: medium
-exec/remote_commands/code_eval: medium
 impact/remote_access/reverse_shell: high
 net/url/embedded: medium

--- a/tests/python/2022.aowdjpawojd-0.0.0/aowdjpawojd/__init__.py.simple
+++ b/tests/python/2022.aowdjpawojd-0.0.0/aowdjpawojd/__init__.py.simple
@@ -3,5 +3,4 @@ anti-static/obfuscation/hex: medium
 anti-static/obfuscation/python: high
 anti-static/packer/blankobf: critical
 data/base64/decode: medium
-exec/remote_commands/code_eval: medium
 net/url/embedded: low

--- a/tests/python/clean/hatch/migrate.py.simple
+++ b/tests/python/clean/hatch/migrate.py.simple
@@ -3,7 +3,6 @@ c2/addr/url: medium
 discover/system/environment: medium
 exec/imports/python: low
 exec/program: medium
-exec/remote_commands/code_eval: medium
 false-positives/py_hatch: low
 fs/directory/list: low
 fs/file/open: low

--- a/tests/python/clean/numpy/misc_util.py.simple
+++ b/tests/python/clean/numpy/misc_util.py.simple
@@ -6,7 +6,6 @@ discover/system/platform: medium
 evasion/file/prefix: medium
 exec/install_additional/pip_install: medium
 exec/program: medium
-exec/remote_commands/code_eval: medium
 exec/shell/command: medium
 fs/directory/list: low
 fs/directory/traverse: medium

--- a/tests/python/clean/open_clip_train/data.py.simple
+++ b/tests/python/clean/open_clip_train/data.py.simple
@@ -2,7 +2,6 @@
 anti-behavior/random_behavior: low
 c2/addr/url: medium
 exec/imports/python: low
-exec/remote_commands/code_eval: medium
 fs/file/exists: low
 fs/file/read: low
 net/download: medium

--- a/tests/python/clean/pydevd/setup_pydevd_cython.py.simple
+++ b/tests/python/clean/pydevd/setup_pydevd_cython.py.simple
@@ -2,7 +2,6 @@
 c2/addr/url: medium
 discover/system/platform: medium
 exec/imports/python: low
-exec/remote_commands/code_eval: medium
 fs/directory/list: low
 fs/file/delete: low
 fs/file/exists: low

--- a/tests/python/clean/setuptools/namespaces.py.simple
+++ b/tests/python/clean/setuptools/namespaces.py.simple
@@ -2,7 +2,6 @@
 c2/addr/url: medium
 data/encoding/json_encode: low
 exec/imports/python: low
-exec/remote_commands/code_eval: medium
 exec/shell/command: medium
 false-positives/setuptools: low
 fs/directory/create: low

--- a/tests/ruby/2019.bootstrap-sass/middleware.rb.simple
+++ b/tests/ruby/2019.bootstrap-sass/middleware.rb.simple
@@ -2,7 +2,6 @@
 anti-static/base64/eval: high
 c2/addr/url: medium
 data/base64/decode: medium
-exec/remote_commands/code_eval: medium
 net/http: low
 net/http/cookies: medium
 os/fd/sendfile: low

--- a/tests/ruby/2019.rest-client/pastebin.rb.simple
+++ b/tests/ruby/2019.rest-client/pastebin.rb.simple
@@ -7,7 +7,6 @@ data/base64/decode: medium
 data/embedded/base64: medium
 data/encoding/base64: low
 data/encoding/json_decode: low
-exec/remote_commands/code_eval: medium
 impact/remote_access/payload: high
 net/http: low
 net/http/cookies: medium

--- a/tests/ruby/2019.rest-client/request.rb.simple
+++ b/tests/ruby/2019.rest-client/request.rb.simple
@@ -1,5 +1,4 @@
 # ruby/2019.rest-client/request.rb: critical
 c2/tool_transfer/download: high
-exec/remote_commands/code_eval: high
 impact/remote_access/remote_eval: critical
 net/url/embedded: low


### PR DESCRIPTION
This PR tightens up our per-language rules and attempts to not alert on completely unrelated filetypes (e.g., Go files probably don't have JS obfuscation). We need to figure out a way to define global rules in a centralized manner, but that's for a future PR.

Given the small number of behavior removals and the associated file types, this is likely doing what we want (e.g., JS files no longer having Python behaviors and vice versa).

I did a few local scans and the false-positives weren't present compared to the current release.

These changes:
```
🔎 Scanning "/Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk"
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/cli.py
│     • net/download/fetch — fetches python and executes python script: curl -s https://api.github.com/repos/mahmoud/glom/events | python -m glom
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/core.py
│     • anti-static/obfuscation/python — Indirectly refers to Python builtins: getattr(__builtins__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/requests/__pycache__/__init__.cpython-313.pyc
│     • net/http/post — posts content to hardcoded HTTP site: requests.post('https://httpbin.org/post
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/rpds/rpds.cpython-313-x86_64-linux-gnu.so
│     • sus/compiler — built with multiple versions of GCC: GCC: (GNU) 10.2.1 20210130 (Red Hat 10.2.1-11), GCC: (GNU) 4.8.5 20150623 (Red Hat 4.8.5-44)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_wheel.py
│     • fs/permission/modify — Makes path world writeable and executable: chmod(runsh, 0o777)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/lexers/_mysql_builtins.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/__pycache__/cli.cpython-313.pyc
│     • net/download/fetch — fetches python and executes python script: curl -s https://api.github.com/repos/mahmoud/glom/events | python -m glom
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_develop.py
│     • impact/remote_access/py_setuptools — Python library installer that executes external commands:
│     subprocess.check_call(pkg_resources_imp), subprocess.check_call(develop_cmd), subprocess.check_call(install_cmd), subprocess.check_call(try_import)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/_distutils/tests/test_spawn.py
│     • fs/permission/modify — Makes path world writeable and executable: chmod(exe, 0o777)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_easy_install.py
│     • impact/remote_access/py_setuptools — Python library installer that executes external commands: subprocess.Popen(cmd).wait, subprocess.run(
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/urllib3/response.py
│     • net/http/content_length — Sets HTTP content length to hard-coded value: Content-Length: 42
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/click/__pycache__/core.cpython-313.pyc
│     • anti-static/obfuscation/reverse — reversed function definition: ntrols if the cleanup f
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/requests/__init__.py
│     • net/http/post — posts content to hardcoded HTTP site: requests.post('https://httpbin.org/post
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/unistring.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/mutation.py
│     • anti-static/obfuscation/python — Indirectly refers to Python builtins: getattr(__builtins__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/click/core.py
│     • anti-static/obfuscation/reverse — reversed function definition: ntrols if the cleanup f
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/urllib3/contrib/emscripten/response.py
│     • net/http/content_length — Sets HTTP content length to hard-coded value: Content-Length: 42
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/lexers/_scilab_builtins.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,

💡 For detailed analysis, try "mal analyze <path>"
```

Main:
```
🔎 Scanning "/Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk"
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/requests/__pycache__/__init__.cpython-313.pyc
│     • net/http/post — posts content to hardcoded HTTP site: requests.post('https://httpbin.org/post
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/urllib3/contrib/emscripten/response.py
│     • net/http/content_length — Sets HTTP content length to hard-coded value: Content-Length: 42
├─ 😈 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/click/core.py
│     • anti-static/obfuscation/reverse — multiple reversed javascript calls: ntrols if the cleanup f, nd arguments descr
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/cli.py
│     • net/download/fetch — fetches python and executes python script: curl -s https://api.github.com/repos/mahmoud/glom/events | python -m glom
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/unistring.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_easy_install.py
│     • impact/remote_access/py_setuptools — Python library installer that executes external commands: subprocess.Popen(cmd).wait, subprocess.run(
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/mutation.py
│     • anti-static/obfuscation/python — Indirectly refers to Python builtins: getattr(__builtins__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/_distutils/tests/test_spawn.py
│     • fs/permission/modify — Makes path world writeable and executable: chmod(exe, 0o777)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/rpds/rpds.cpython-313-x86_64-linux-gnu.so
│     • sus/compiler — built with multiple versions of GCC: GCC: (GNU) 10.2.1 20210130 (Red Hat 10.2.1-11), GCC: (GNU) 4.8.5 20150623 (Red Hat 4.8.5-44)
├─ 😈 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/click/__pycache__/core.cpython-313.pyc
│     • anti-static/obfuscation/reverse — multiple reversed javascript calls: ntrols if the cleanup f, nd arguments descr
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/core.py
│     • anti-static/obfuscation/python — Indirectly refers to Python builtins: getattr(__builtins__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/requests/__init__.py
│     • net/http/post — posts content to hardcoded HTTP site: requests.post('https://httpbin.org/post
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/urllib3/response.py
│     • net/http/content_length — Sets HTTP content length to hard-coded value: Content-Length: 42
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/lexers/_mysql_builtins.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_develop.py
│     • impact/remote_access/py_setuptools — Python library installer that executes external commands:
│     subprocess.check_call(pkg_resources_imp), subprocess.check_call(develop_cmd), subprocess.check_call(install_cmd), subprocess.check_call(try_import)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/pygments/lexers/_scilab_builtins.py
│     • evasion/covert_location/python_file — python file reads itself, possibly hiding additional instructions: open(__file__,
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/setuptools/tests/test_wheel.py
│     • fs/permission/modify — Makes path world writeable and executable: chmod(runsh, 0o777)
├─ 🛑 /Users/.../Downloads/semgrep/py3-semgrep-1.120.0-r0.apk ∴ /usr/lib/python3.13/site-packages/glom/__pycache__/cli.cpython-313.pyc
│     • net/download/fetch — fetches python and executes python script: curl -s https://api.github.com/repos/mahmoud/glom/events | python -m glom

💡 For detailed analysis, try "mal analyze <path>"
```