### PR TITLE
Use make yara-x-compile in CI

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -29,16 +29,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install yara-x
+      - name: Run make yara-x-compile
         run: |
-          wget https://github.com/VirusTotal/yara-x/releases/download/v0.15.0/yara-x-v0.15.0-x86_64-unknown-linux-gnu.gz -O yara-x.gz
-          tar -xzvf yara-x.gz && mv yr /usr/local/bin/ && rm yara-x.gz
-      - name: Verify yr installation
-        run: |
-          yr --version
-      - name: Run yr compile
-        run: |
-          yr compile --path-as-namespace -w rules/
+          make yara-x-compile
           ret=$?
           if [[ $ret -ne 0 ]]; then
             echo "Rule compilation failed; address findings and commit the changes"

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ yara-x-fmt: $(YARA_X_BIN)
 	find rules -type f -name "*.yara" -execdir "$(YARA_X_BIN)" fmt {} \;
 
 yara-x-compile: $(YARA_X_BIN)
-	"$(YARA_X_BIN)" compile ./rules/
+	"$(YARA_X_BIN)" compile --path-as-namespace -w rules/
 
 .PHONY: _lint $(LINTERS)
 _lint: $(LINTERS)

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ YARA_X_BIN := $(LINT_ROOT)/out/linters/yr-$(YARA_X_VERSION)-$(LINT_ARCH)
 $(YARA_X_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters
 	rm -rf $(LINT_ROOT)/out/linters/yr
-	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER)$(LINT_PLATFORM_SUFFIX).gz -o yara-x.gzip
-	echo "$(YARA_X_SHA) *yara-x.gzip" | shasum -a 256 --check
-	tar -xzvf yara-x.gzip && mv yr $(LINT_ROOT)/out/linters && rm yara-x.gzip
+	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER)$(LINT_PLATFORM_SUFFIX).gz -o yara-x.gz
+	echo "$(YARA_X_SHA) *yara-x.gz" | shasum -a 256 --check
+	tar -xzvf yara-x.gz && mv yr $(LINT_ROOT)/out/linters && rm yara-x.gz
 	mv $(LINT_ROOT)/out/linters/yr $@
 
 LINTERS += golangci-lint-lint


### PR DESCRIPTION
Closes: #939

`make yara-x-compile` installs the correct version of `yr` and doesn't require any knowledge about where the binary lands.