### PR TITLE
Access kind.Ext only if kind is not nil

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -438,8 +438,10 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 			ignoreMalcontent = true
 		}
 
-		if !fileMatchesRule(m.Metadata(), kind.Ext) {
-			continue
+		if kind != nil && kind.Ext != "" {
+			if !fileMatchesRule(m.Metadata(), kind.Ext) {
+				continue
+			}
 		}
 
 		override := slices.Contains(m.Tags(), "override")


### PR DESCRIPTION
This was very subtle and caused panics with data files that have no MIME type, but is definitely something that needs to be guarded against.

It was hard to find a file to re-pro this locally which made the issue seem related to Wolfi itself but in the end it was easy enough to check the file's (`/etc/os-release`) type which ended up being nil.