### PR TITLE
Add application/jar to zipMIME map

### DIFF
--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -20,6 +20,7 @@ import (
 var initZipPool sync.Once
 
 var zipMIME = map[string]struct{}{
+	"application/jar":              {},
 	"application/java-archive":     {},
 	"application/x-wheel+zip":      {},
 	"application/x-zip":            {},


### PR DESCRIPTION
Small bugfix for determining filetype when extracting JARs. I noticed this when trying to scan a Sonarqube package.