### PR TITLE
Fix partial read edge cases

### DIFF
--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -90,20 +90,23 @@ func ExtractGzip(ctx context.Context, d string, f string) error {
 		}
 
 		n, err := gr.Read(buf)
+		if n > 0 {
+			written += int64(n)
+			if written > maxBytes {
+				return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
+			}
+
+			if _, writeErr := out.Write(buf[:n]); writeErr != nil {
+				return fmt.Errorf("failed to write file contents: %w", writeErr)
+			}
+		}
+
 		if errors.Is(err, io.EOF) {
 			break
 		}
+
 		if err != nil {
 			return fmt.Errorf("failed to read file contents: %w", err)
-		}
-
-		written += int64(n)
-		if written > maxBytes {
-			return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
-		}
-
-		if _, err := out.Write(buf[:n]); err != nil {
-			return fmt.Errorf("failed to write file contents: %w", err)
 		}
 	}
 

--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -128,20 +128,22 @@ func ExtractRPM(ctx context.Context, d, f string) error {
 			}
 
 			n, err := cr.Read(buf)
+			if n > 0 {
+				written += int64(n)
+				if written > maxBytes {
+					return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
+				}
+				if _, writeErr := out.Write(buf[:n]); writeErr != nil {
+					return fmt.Errorf("failed to write file contents: %w", writeErr)
+				}
+			}
+
 			if errors.Is(err, io.EOF) {
 				break
 			}
+
 			if err != nil {
 				return fmt.Errorf("failed to read file contents: %w", err)
-			}
-
-			written += int64(n)
-			if written > maxBytes {
-				return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
-			}
-
-			if _, err := out.Write(buf[:n]); err != nil {
-				return fmt.Errorf("failed to write file contents: %w", err)
 			}
 		}
 

--- a/pkg/archive/zlib.go
+++ b/pkg/archive/zlib.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"compress/zlib"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,20 +64,23 @@ func ExtractZlib(ctx context.Context, d string, f string) error {
 		}
 
 		n, err := zr.Read(buf)
-		if err == io.EOF {
+		if n > 0 {
+			written += int64(n)
+			if written > maxBytes {
+				return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
+			}
+
+			if _, writeErr := out.Write(buf[:n]); writeErr != nil {
+				return fmt.Errorf("failed to write file contents: %w", writeErr)
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
 			break
 		}
+
 		if err != nil {
 			return fmt.Errorf("failed to read file contents: %w", err)
-		}
-
-		written += int64(n)
-		if written > maxBytes {
-			return fmt.Errorf("file exceeds maximum allowed size (%d bytes): %s", maxBytes, target)
-		}
-
-		if _, err := out.Write(buf[:n]); err != nil {
-			return fmt.Errorf("failed to write file contents: %w", err)
 		}
 	}
 


### PR DESCRIPTION
In certain cases, we were encountering partial reads which caused interesting scan results. This PR handles those edge cases and fixes partial reads in our optimized loops.

I ran several local scans with these changes and they address what I was seeing.