### PR TITLE
Update yara-x to 1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SAMPLES_REPO ?= chainguard-dev/malcontent-samples
 SAMPLES_COMMIT ?= f948cfd0f9d2a35a2452fe43ea4d094979652103
 YARA_X_REPO ?= virusTotal/yara-x
-YARA_X_COMMIT ?= 3537bcfd9c4f2dc6a38f266079a40c1a1dc5eb72
+YARA_X_COMMIT ?= 35bbdabb8c7ba6b0351d675e06ad074abfa3b522
 
 # BEGIN: lint-install ../malcontent
 # http://github.com/tinkerbell/lint-install
@@ -52,12 +52,12 @@ $(GOLANGCI_LINT_BIN):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
 	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
-YARA_X_VERSION ?= v0.15.0
+YARA_X_VERSION ?= v1.0.0
 YARA_X_SHA :=
 ifeq ($(LINT_OS),Darwin)
-	YARA_X_SHA=c9463e2d2c5662e103fe85e1dab999338e446280c54fb5a24f6af8fde2018fc6
+	YARA_X_SHA=d2cb19fe77289ce763e0a0b1bec6f03f4a751c44bd8310a808ad1aeafba41fbe
 else
-	YARA_X_SHA=56b207268dd8cfd237bfeb75199e3133fcec1b729e8113d8561c267ac3dccad6
+	YARA_X_SHA=aeba6f56c50a0c931ab8f6e8f3dbe60b8affc8452e1f9c90da47e8357f524852
 endif
 YARA_X_BIN := $(LINT_ROOT)/out/linters/yr-$(YARA_X_VERSION)-$(LINT_ARCH)
 $(YARA_X_BIN):

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/VirusTotal/yara-x/go v0.15.0
+	github.com/VirusTotal/yara-x/go v1.0.0
 	github.com/agext/levenshtein v1.2.3
 	github.com/cavaliergopher/cpio v1.0.1
 	github.com/cavaliergopher/rpm v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/VirusTotal/yara-x/go v0.15.0 h1:CHNvN6s38ctySGtlZhS44JnWdpKDbIpSmhMyt/JmQps=
-github.com/VirusTotal/yara-x/go v0.15.0/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
+github.com/VirusTotal/yara-x/go v1.0.0 h1:FuAhyAfM0mSeNeK44kdOP+ovWn3iN7hvkrxX0gQw054=
+github.com/VirusTotal/yara-x/go v1.0.0/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=


### PR DESCRIPTION
`yara-x` is officially stable now; this PR updates our usage to `1.0.0`.