### PR TITLE
Clean up false positives for EOL Go and Linux Test Project

### DIFF
--- a/rules/false_positives/go_1.17.yara
+++ b/rules/false_positives/go_1.17.yara
@@ -1,0 +1,11 @@
+rule go_1_17_override: override {
+  meta:
+    description                            = "linux_amd64/link"
+    ARKBIRD_SOLG_APT_APT34_RDAT_Feb_2021_1 = "low"
+
+  strings:
+    $build_id = "OZ4MIHRt5yYNzPxU6QuH/qAeXWMvY1RJrUXB6xka1/4fdCwddvzTvjJBZrCo2S/DCU7CoUCdrRvbKi6ROH6"
+
+  condition:
+    all of them
+}

--- a/rules/false_positives/ltp.yara
+++ b/rules/false_positives/ltp.yara
@@ -1,0 +1,24 @@
+rule ltp_dirtypipe_override: override {
+  meta:
+    description                          = "testcases/bin/dirtypipe"
+    Linux_Exploit_CVE_2022_0847_e831c285 = "high"
+
+  strings:
+    $dirtypipe = "@dirtypipe.c"
+    $ltp       = "LTPROOT                  Prefix for installed LTP (default: /opt/ltp)"
+
+  condition:
+    all of them
+}
+
+rule ltp_runsched_override: override {
+  meta:
+    description                                   = "testcases/bin/run_sched_cliserv.sh"
+    SIGNATURE_BASE_WEBSHELL_ASPX_Proxyshell_Aug15 = "harmless"
+
+  strings:
+    $cmd = "pthcli 127.0.0.1 $LTPROOT/testcases/bin/data"
+
+  condition:
+    all of them
+}


### PR DESCRIPTION
This PR cleans up a few remaining false positives. 

The rule triggering against LTP's Dirtypipe test is valid since it's testing the actual vector of attack, but it makes sense to treat it like other red-teaming tools. The other finding was an outright false-positive.