### PR TITLE
Add exception for php_image_include rule

### DIFF
--- a/rules/evasion/covert-location/php_image.yara
+++ b/rules/evasion/covert-location/php_image.yara
@@ -7,8 +7,12 @@ rule php_image_include: critical {
     $php     = "<?php"
     $include = /include\s*\(\s*[^\.]+\.(png|jpg|gif|bmp)/
 
+    // https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php#L9
+    // https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/Resources/assets/images/favicon.png.base64
+    $not_symfony = "include('assets/images/favicon.png.base64')"
+
   condition:
-    filesize < 5242880 and all of them
+    filesize < 5242880 and all of them and none of ($not*)
 }
 
 rule php_in_image: critical {

--- a/rules/evasion/covert-location/php_image.yara
+++ b/rules/evasion/covert-location/php_image.yara
@@ -9,7 +9,8 @@ rule php_image_include: critical {
 
     // https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/Resources/views/exception_full.html.php#L9
     // https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/ErrorHandler/Resources/assets/images/favicon.png.base64
-    $not_symfony = "include('assets/images/favicon.png.base64')"
+    $not_symfony1 = "include('assets/images/favicon.png.base64')"
+    $not_symfony2 = "<a href=\"https://symfony.com/doc/<?= Symfony\\Component\\HttpKernel\\Kernel::VERSION; ?>/index.html\">"
 
   condition:
     filesize < 5242880 and all of them and none of ($not*)


### PR DESCRIPTION
This PR adds a straightforward exception for the embedding of Symfony's favicon as base64 in the `php_image_include` rule.