### PR TITLE
Address false positives with knative and new x86 third-party rule

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -37,6 +37,7 @@ var badRules = map[string]bool{
 	"SIGNATURE_BASE_SUSP_ELF_LNX_UPX_Compressed_File":     true,
 	"DELIVRTO_SUSP_SVG_Foreignobject_Nov24":               true,
 	"CAPE_Eternalromance":                                 true,
+	"CAPE_Formhookb":                                      true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,

--- a/rules/false_positives/knative.yara
+++ b/rules/false_positives/knative.yara
@@ -1,14 +1,11 @@
+import "hash"
+
 rule kobalos_override: override {
   meta:
     description                        = "webhook"
     ESET_Kobalos                       = "harmless"
     SIGNATURE_BASE_APT_MAL_LNX_Kobalos = "harmless"
 
-  strings:
-    $knative1 = "knative.dev/operator"
-    $knative2 = "knative.dev/pkg/webhook"
-    $knative3 = "main.newConversionController"
-
   condition:
-    all of them
+    (hash.sha256(0, filesize) == "572235f7943a8bab5377ed94c9dbdd8c2471e08e19ff6bc1edd0f1f3680ab25d")
 }

--- a/rules/false_positives/knative.yara
+++ b/rules/false_positives/knative.yara
@@ -1,0 +1,14 @@
+rule kobalos_override: override {
+  meta:
+    description                        = "webhook"
+    ESET_Kobalos                       = "harmless"
+    SIGNATURE_BASE_APT_MAL_LNX_Kobalos = "harmless"
+
+  strings:
+    $knative1 = "knative.dev/operator"
+    $knative2 = "knative.dev/pkg/webhook"
+    $knative3 = "main.newConversionController"
+
+  condition:
+    all of them
+}


### PR DESCRIPTION
A couple of our new rules were rendering false positives for a handful of packages/dependencies.

The `CAPE_Formhookb` rule was wrong across every `.dll` and `.exe` file it detected (which I double-checked with VT).

The Knative findings were only a subset of the strings which is noisy (the problematic strings were not present). This is the problem with using `any of them` rather than doing something like `1 of $problem and any of $whatever_else`.