### PR TITLE
Bump yara-x to 1.2.1

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,7 +36,7 @@ jobs:
           fetch-tags: true
           repository: virusTotal/yara-x
           path: yara-x
-          ref: refs/tags/v1.0.0
+          ref: refs/tags/v1.2.1
       - name: Install Rust for yara-x-capi
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SAMPLES_REPO ?= chainguard-dev/malcontent-samples
 SAMPLES_COMMIT ?= f948cfd0f9d2a35a2452fe43ea4d094979652103
 YARA_X_REPO ?= virusTotal/yara-x
-YARA_X_COMMIT ?= 35bbdabb8c7ba6b0351d675e06ad074abfa3b522
+YARA_X_COMMIT ?= 02d649bd1ff35789757a515d0fd3bbdfaf411ef3
 
 # BEGIN: lint-install ../malcontent
 # http://github.com/tinkerbell/lint-install
@@ -52,12 +52,17 @@ $(GOLANGCI_LINT_BIN):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LINT_ROOT)/out/linters $(GOLANGCI_LINT_VERSION)
 	mv $(LINT_ROOT)/out/linters/golangci-lint $@
 
-YARA_X_VERSION ?= v1.0.0
+YARA_X_VERSION ?= v1.2.1
 YARA_X_SHA :=
 ifeq ($(LINT_OS),Darwin)
-	YARA_X_SHA=d2cb19fe77289ce763e0a0b1bec6f03f4a751c44bd8310a808ad1aeafba41fbe
+	ifeq ($(shell uname -m),arm64)
+		LINT_ARCH = aarch64
+		YARA_X_SHA = b85ae01e5d16f99f84613e688a05986a56b5c849148895a74ee80115cb6acdad
+	else
+		YARA_X_SHA = f4fb8a75af3a82a7377758d6dc09c2d46c230d26d83991a4c27e93c17dae78e9
+	endif
 else
-	YARA_X_SHA=aeba6f56c50a0c931ab8f6e8f3dbe60b8affc8452e1f9c90da47e8357f524852
+	YARA_X_SHA = 8f018934fe80a5428bca0fcb4778e188210e77f03b1507bbbfb4b1e30af3051f
 endif
 YARA_X_BIN := $(LINT_ROOT)/out/linters/yr-$(YARA_X_VERSION)-$(LINT_ARCH)
 $(YARA_X_BIN):

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/VirusTotal/yara-x/go v1.0.0
+	github.com/VirusTotal/yara-x/go v1.2.1
 	github.com/agext/levenshtein v1.2.3
 	github.com/cavaliergopher/cpio v1.0.1
 	github.com/cavaliergopher/rpm v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/VirusTotal/yara-x/go v1.0.0 h1:FuAhyAfM0mSeNeK44kdOP+ovWn3iN7hvkrxX0gQw054=
-github.com/VirusTotal/yara-x/go v1.0.0/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
+github.com/VirusTotal/yara-x/go v1.2.1 h1:eOFTHXW7GKEQ7JfvJ6XzMMYcAMDg9FqcpJBSV1EIioQ=
+github.com/VirusTotal/yara-x/go v1.2.1/go.mod h1:lgXP/nkYX349MVowrtTtU5hzMdCOWQLv3+wKll9+0F8=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=


### PR DESCRIPTION
This PR bumps yara-x to `1.2.1`. There were no Go tags for `1.0.1` or `1.1.0` until `1.2.0` was released and `1.2.0` had a regression.

I also added a Makefile condition to pull down the arm64 macOS `yr` binary to speed up local rule compilations/formatting instead of relying on Rosetta emulation.