### PR TITLE
Ensure tar pool is initialized even when going the deb route

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -250,11 +250,6 @@ func handleDirectory(target string) error {
 
 // handleFile extracts valid files within .deb or .tar archives.
 func handleFile(target string, tr *tar.Reader) error {
-	// Initialize the tar pool if it hasn't been initialized yet.
-	initTarPool.Do(func() {
-		tarPool = pool.NewBufferPool(runtime.GOMAXPROCS(0))
-	})
-
 	buf := tarPool.Get(extractBuffer)
 	defer tarPool.Put(buf)
 


### PR DESCRIPTION
Extracting either a deb or a tar both requires the tar pool to be initialized. Currently, on the deb route, it's not initialized at all and so it panics if we extract a deb before extracting a tar.

Fixes #1012