### PR TITLE
Fix indefinite block when Config struct is initialized separately

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -158,7 +158,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	}
 
 	initializeOnce.Do(func() {
-		scannerPool = pool.NewScannerPool(yrs, c.Concurrency)
+		scannerPool = pool.NewScannerPool(yrs, getMaxConcurrency(c.Concurrency))
 	})
 
 	scanner := scannerPool.Get()


### PR DESCRIPTION
If we use something like:
```go
_, err := action.Scan(ctx, malcontent.Config{
	IncludeDataFiles: true,
	ScanPaths:        []string{testFile},
	RuleFS:           []fs.FS{rules.FS, thirdparty.FS},
})

if err != nil {
	t.Fatalf("Scan(%q) error = %v, want nil", testFile, err)
}
```

The new channel-based scanner pool will block indefinitely because `c.Concurrency` will default to `0` so no scanners will be created. This ensures that we initialize the pool regardless of how the Config is initialized.