### PR TITLE
Fix QuantityIncreasesRisk edge case with only high behaviors present

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -174,7 +174,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 	// This is a short-circuit that avoids any report generation logic
 	risk := report.HighestMatchRisk(mrs)
 	threshold := max(3, c.MinFileRisk, c.MinRisk)
-	if c.Scan && risk < threshold {
+	if c.Scan && risk < threshold && !c.QuantityIncreasesRisk {
 		fr := &malcontent.FileReport{Skipped: "overall risk too low for scan", Path: path}
 		if isArchive {
 			os.RemoveAll(path)
@@ -182,7 +182,7 @@ func scanSinglePath(ctx context.Context, c malcontent.Config, path string, ruleF
 		return fr, nil
 	}
 
-	fr, err := report.Generate(ctx, path, mrs, c, archiveRoot, logger, fc, kind)
+	fr, err := report.Generate(ctx, path, mrs, c, archiveRoot, logger, fc, kind, risk)
 	if err != nil {
 		return nil, NewFileReportError(err, path, TypeGenerateError)
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -377,7 +377,7 @@ func fileMatchesRule(meta []yarax.Metadata, ext string) bool {
 	return true
 }
 
-func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte, kind *programkind.FileType) (*malcontent.FileReport, error) {
+func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcontent.Config, expath string, _ *clog.Logger, fc []byte, kind *programkind.FileType, highestRisk int) (*malcontent.FileReport, error) {
 	if ctx.Err() != nil {
 		return &malcontent.FileReport{}, ctx.Err()
 	}
@@ -408,7 +408,6 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 	risk := 0
 	riskCounts := make(map[int]int, 0)
 
-	highestRisk := HighestMatchRisk(mrs)
 	// Store match rules in a map for future override operations
 	mrsMap := createMatchRulesMap(mrs, matchCount)
 
@@ -435,9 +434,9 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 		switch {
 		case risk == -1:
 			continue
-		case risk < minScore && !ignoreMalcontent && !override:
+		case !c.Scan && risk < minScore && !ignoreMalcontent && !override:
 			continue
-		case c.Scan && risk < highestRisk && !ignoreMalcontent && !override:
+		case c.Scan && risk < highestRisk && !c.QuantityIncreasesRisk && !ignoreMalcontent && !override:
 			continue
 		}
 
@@ -483,13 +482,15 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 	}
 
 	// Update the behaviors to account for overrides
-	fr.Behaviors = handleOverrides(fr.Behaviors, fr.Overrides, minScore)
+	fr.Behaviors = handleOverrides(fr.Behaviors, fr.Overrides, minScore, c.Scan, c.QuantityIncreasesRisk)
 
 	// Adjust the overall risk if we deviated from overallRiskScore
 	// Scans will still need to drop <= medium results
-	newRisk := highestBehaviorRisk(fr)
-	if overallRiskScore != newRisk {
-		overallRiskScore = newRisk
+	overallRiskScore = highestBehaviorRisk(fr)
+
+	// If something has a lot of high, it's probably critical
+	if c.QuantityIncreasesRisk && upgradeRisk(ctx, overallRiskScore, riskCounts, size) {
+		overallRiskScore = 4
 	}
 
 	if c.Scan && overallRiskScore < HIGH {
@@ -501,11 +502,6 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 
 	if all(ignoreSelf, fr.IsMalcontent, ignoreMalcontent, isMalBinary) {
 		fr.Skipped = "ignoring malcontent binary"
-	}
-
-	// If something has a lot of high, it's probably critical
-	if c.QuantityIncreasesRisk && upgradeRisk(ctx, overallRiskScore, riskCounts, size) {
-		overallRiskScore = 4
 	}
 
 	slices.Sort(pledges)
@@ -732,8 +728,6 @@ func upgradeRisk(ctx context.Context, riskScore int, riskCounts map[int]int, siz
 		upgrade = true
 	case highCount > 6:
 		upgrade = true
-	case !upgrade:
-		upgrade = false
 	}
 
 	clog.DebugContextf(ctx, "upgrading risk: high=%d, size=%d", highCount, size)
@@ -779,7 +773,7 @@ func highestBehaviorRisk(fr *malcontent.FileReport) int {
 }
 
 // handleOverrides modifies the behavior slice based on the contents of the override slice.
-func handleOverrides(original, override []*malcontent.Behavior, minScore int) []*malcontent.Behavior {
+func handleOverrides(original, override []*malcontent.Behavior, minScore int, scan, quantityIncreasesRisk bool) []*malcontent.Behavior {
 	behaviorMap := make(map[string]*malcontent.Behavior, len(original))
 	for _, b := range original {
 		behaviorMap[b.RuleName] = b
@@ -798,6 +792,11 @@ func handleOverrides(original, override []*malcontent.Behavior, minScore int) []
 
 	modified := make([]*malcontent.Behavior, 0, len(behaviorMap))
 	for _, b := range behaviorMap {
+		// if running a scan and using quantityIncreasesRisk,
+		// append every behavior so we can handle filtering correctly
+		if scan && quantityIncreasesRisk && b.RiskScore >= 3 {
+			modified = append(modified, b)
+		}
 		if b.RiskScore >= minScore {
 			modified = append(modified, b)
 		}


### PR DESCRIPTION
@jamie-albert pointed out that aggregated high behaviors which register as critical would be dropped when using `--min-risk=critical` and `--min-file-risk=critical`.

This was mainly due to `handleOverrides` dropping any behaviors that weren't greater than or equal to the `minRisk` (4).

This PR fixes that edge case and adds additional guardrails when using `--quantity-increases-risk` so that we preserve any behaviors until we finally get to `if c.QuantityIncreasesRisk && upgradeRisk(ctx, overallRiskScore, riskCounts, size)...`.

I also de-duped the usage of `HighestMatchRisk` so we don't have to do that twice per file.

Verifying that this works:
```
$ out/mal --min-risk=critical --min-file-risk=critical --quantity-increases-risk=true scan ~/Downloads/fps/kibana-9-9.0.4-r0.apk
🔎 Scanning "~/Downloads/fps/kibana-9-9.0.4-r0.apk"
├─ 😈 ~/Downloads/fps/kibana-9-9.0.4-r0.apk ∴ /usr/share/kibana/node_modules/gpt-tokenizer/dist/o200k_base.js
│     • anti-behavior/blocklist/user — avoids execution if user has a particular name:
│     server, george, Louise, Lucas, Julia, Frank, fred, test, Lisa, John, Abby, mike
│     • exfil/stealer/creds — suspected data stealer: Bookmarks, Chromium, Telegram, Firefox, Binance, Discord, Bitcoin, History, Atomic, Chrome, Exodus
│     • impact/exploit — References 'explot'&{0xc000022180}
├─ 😈 ~/Downloads/fps/kibana-9-9.0.4-r0.apk ∴ /usr/share/kibana/node_modules/gpt-tokenizer/src/bpeRanks/o200k_base.js
│     • anti-behavior/blocklist/user — avoids execution if user has a particular name:
│     server, george, Louise, Lucas, Julia, Frank, fred, test, Lisa, John, Abby, mike
│     • exfil/stealer/creds — suspected data stealer: Bookmarks, Chromium, Telegram, Firefox, Binance, Discord, Bitcoin, History, Atomic, Chrome, Exodus
│     • impact/exploit — References 'explot'&{0xc000022180}
├─ 😈 ~/Downloads/fps/kibana-9-9.0.4-r0.apk ∴ /usr/share/kibana/node_modules/@kbn/security-solution-plugin/target/public/securitySolution.chunk.4588.js
│     • c2/addr/url — Contains HTTP hostname with unusual top-level domain: http://401trg.pw/, http://krbtgt.pw/
│     • c2/tool_transfer/download — References known file hosting site:
│     pastebin.com/m44e60e60, pastebin.com/NP64hTQr, pastebin.com/XAG1Hnfd, pastebin.com/qnLmpKuQ, pastebin.com/0dAciksC, pastebin.com/C0arvGxU, p…
│     • c2/tool_transfer/exe_url — accesses hardcoded powershell file endpoint: http://www.searchmiracle.com/silent.exe
│     • c2/tool_transfer/grayware — References websites that host code that can be used maliciously:
│     packetstormsecurity, pentestmonkey.net, exploit-db.com, milw0rm.com, 1337day.com
│     • impact/remote_access/reverse_shell — references a reverse shell: webshell
├─ 😈 ~/Downloads/fps/kibana-9-9.0.4-r0.apk ∴ /usr/share/kibana/node_modules/@kbn/fleet-plugin/target/public/fleet.chunk.720.js
│     • anti-static/obfuscation/bitwise — uses an excessive amount of unsigned bitwise math:
│     function(, charAt(r, charAt(i, charAt(a, charAt(n, charAt(t, a>>>13, a>>>26, l>>>26, o>>>24, t>>>26, d>>>13, h>>>13, m>>>13, b>>>13, k>>>13,…
│     • exec/remote_commands/code_eval — Likely evaluates encrypted content via fromCharCode: fromCharCode(55296+, fromCharCode(i, fromCharCode(e, eval(
│     • net/download/fetch — high-risk fetch command:
│     curl -L -O ${m}/beats/elastic-agent/elastic-agent-${l}-darwin-aarch64.tar.gz ${y}, curl -L -O ${a}/beats/elastic-agent/elastic-agent-${e}-da…

💡 For detailed analysis, try "mal analyze <path>"
```