### PR TITLE
Use wolfi-base:latest to avoid drift

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
     runs-on: mal-ubuntu-latest-8-core
     container:
-      image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
+      image: cgr.dev/chainguard/wolfi-base:latest
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID
@@ -54,7 +54,7 @@ jobs:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
     runs-on: mal-ubuntu-latest-8-core
     container:
-      image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
+      image: cgr.dev/chainguard/wolfi-base:latest
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -117,7 +117,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     container:
-      image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
+      image: cgr.dev/chainguard/wolfi-base:latest
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
     runs-on: mal-ubuntu-latest-8-core
     container:
-      image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
+      image: cgr.dev/chainguard/wolfi-base:latest
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID


### PR DESCRIPTION
Pinning to digests with `wolfi-base` is workable with automation but we don't have any configured to handle this bump, so we should just pull in the latest updates as they're available (which is what we do with all of the APKs anyway).