### PR TITLE
Malcontent: change extraction error default

### DIFF
--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -291,7 +291,7 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:        "exit-extraction",
-				Value:       true,
+				Value:       false,
 				Usage:       "Exit when encountering file extraction errors",
 				Destination: &exitExtractionFlag,
 			},


### PR DESCRIPTION
Malcontent defaults to exiting on extraction errors by default, which
ends up being something a lot of people trip over when trying to figure
out what's being detected in an artifact. Fix that by defaulting to not
exiting on extraction errors.

Also, always report when archive extraction fails for a given artifact.
Previously, if the `--exit-extraction=false` flag was set, malcontent
would then silently ignore the extraction error, rather than continuing
to report it.
