### PR TITLE
Bump ulimit -n value for containerized Jobs

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -30,7 +30,7 @@ jobs:
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0
-        --ulimit nofile=1024:1024
+        --ulimit nofile=4096:4096
         --ulimit nproc=4096:4096
     steps:
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0
-        --ulimit nofile=1024:1024
+        --ulimit nofile=4096:4096
         --ulimit nproc=4096:4096
     steps:
       - name: Install dependencies

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -128,7 +128,7 @@ jobs:
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0
-        --ulimit nofile=1024:1024
+        --ulimit nofile=4096:4096
         --ulimit nproc=4096:4096
     steps:
       - name: Install dependencies

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -24,7 +24,7 @@ jobs:
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0
-        --ulimit nofile=1024:1024
+        --ulimit nofile=4096:4096
         --ulimit nproc=4096:4096
     permissions:
       contents: write


### PR DESCRIPTION
We've started seeing regular third-party update failures around too many open files:
```
💣 test data refresh failed: refresh sample data for tests/macOS/2024.CryptoNews/CryptoNews-PR-Agreement.simple: process: failed to handle error for path out/chainguard-dev/malcontent-samples/macOS/2024.CryptoNews/CryptoNews-PR-Agreement: error type not FileReportError: open out/chainguard-dev/malcontent-samples/macOS/2024.CryptoNews/CryptoNews-PR-Agreement: too many open files
```

This PR quadruples the limit everywhere for consistency which should give us some breathing room.