### PR TITLE
Add rule for recent Crate compromises; run fmt to pick up new yara-x newline formatting

### DIFF
--- a/rules/anti-static/obfuscation/obfuscate.yara
+++ b/rules/anti-static/obfuscation/obfuscate.yara
@@ -20,4 +20,3 @@ rule obfuscator {
   condition:
     $obfuscate
 }
-

--- a/rules/anti-static/xor/xor-paths.yara
+++ b/rules/anti-static/xor/xor-paths.yara
@@ -29,4 +29,3 @@ rule xor_paths: high {
   condition:
     filesize < 10MB and any of them
 }
-

--- a/rules/c2/addr/discord.yara
+++ b/rules/c2/addr/discord.yara
@@ -9,4 +9,3 @@ rule discord: medium {
   condition:
     any of them
 }
-

--- a/rules/c2/addr/telegram.yara
+++ b/rules/c2/addr/telegram.yara
@@ -9,4 +9,3 @@ rule telegram: medium {
   condition:
     any of them
 }
-

--- a/rules/c2/connect/curl_easy.yara
+++ b/rules/c2/connect/curl_easy.yara
@@ -8,4 +8,3 @@ rule curl_easy: medium {
   condition:
     filesize < 1MB and all of them
 }
-

--- a/rules/c2/connect/ping_pong.yara
+++ b/rules/c2/connect/ping_pong.yara
@@ -10,4 +10,3 @@ rule ping_pong: medium {
   condition:
     filesize < 1MB and all of them
 }
-

--- a/rules/c2/connect/server.yara
+++ b/rules/c2/connect/server.yara
@@ -8,4 +8,3 @@ rule connect_server: medium {
   condition:
     filesize < 1MB and any of them
 }
-

--- a/rules/c2/tool_transfer/bitsadmin.yara
+++ b/rules/c2/tool_transfer/bitsadmin.yara
@@ -21,4 +21,3 @@ rule bitsadmin_transfer: high {
   condition:
     filesize < 250KB and all of them
 }
-

--- a/rules/credential/cloud/gcloud.yara
+++ b/rules/credential/cloud/gcloud.yara
@@ -9,4 +9,3 @@ rule gcloud_config_value: medium {
   condition:
     any of them
 }
-

--- a/rules/credential/gaming/minecraft.yara
+++ b/rules/credential/gaming/minecraft.yara
@@ -33,4 +33,3 @@ rule essential_microsoft_accounts: high {
   condition:
     all of them
 }
-

--- a/rules/crypto/public_key.yara
+++ b/rules/crypto/public_key.yara
@@ -19,4 +19,3 @@ rule verifies_public_key: medium {
   condition:
     any of them
 }
-

--- a/rules/data/embedded/base64.yara
+++ b/rules/data/embedded/base64.yara
@@ -19,4 +19,3 @@ rule base64_content_reversed: high {
   condition:
     any of them
 }
-

--- a/rules/data/embedded/embedded-pem-certificate.yara
+++ b/rules/data/embedded/embedded-pem-certificate.yara
@@ -8,4 +8,3 @@ rule begin_cert {
   condition:
     any of them
 }
-

--- a/rules/data/embedded/embedded-pem-test_key.yara
+++ b/rules/data/embedded/embedded-pem-test_key.yara
@@ -8,4 +8,3 @@ rule testing_key {
   condition:
     any of them
 }
-

--- a/rules/data/embedded/embedded-ssh-signature.yara
+++ b/rules/data/embedded/embedded-ssh-signature.yara
@@ -8,4 +8,3 @@ rule ssh_signature: medium {
   condition:
     any of them
 }
-

--- a/rules/data/encoding/audio-pcm.yara
+++ b/rules/data/encoding/audio-pcm.yara
@@ -7,4 +7,3 @@ rule pcm: harmless {
   condition:
     any of them
 }
-

--- a/rules/data/encoding/marshal.yara
+++ b/rules/data/encoding/marshal.yara
@@ -8,4 +8,3 @@ rule encoding_py_marshal: medium {
   condition:
     filesize < 1MB and any of them
 }
-

--- a/rules/data/random/insecure.yara
+++ b/rules/data/random/insecure.yara
@@ -22,4 +22,3 @@ rule insecure_rand {
   condition:
     any of them in (1000..3000)
 }
-

--- a/rules/discover/cloud/aws-metadata.yara
+++ b/rules/discover/cloud/aws-metadata.yara
@@ -8,4 +8,3 @@ rule aws_metadata {
   condition:
     any of them
 }
-

--- a/rules/discover/cloud/google-docs.yara
+++ b/rules/discover/cloud/google-docs.yara
@@ -6,4 +6,3 @@ rule google_docs_user: high {
   condition:
     any of them
 }
-

--- a/rules/discover/cloud/google-metadata.yara
+++ b/rules/discover/cloud/google-metadata.yara
@@ -8,4 +8,3 @@ rule google_metadata {
   condition:
     any of them
 }
-

--- a/rules/discover/cloud/google-storage.yara
+++ b/rules/discover/cloud/google-storage.yara
@@ -8,4 +8,3 @@ rule go_import {
   condition:
     any of them
 }
-

--- a/rules/evasion/bypass_security/linux/iptables.yara
+++ b/rules/evasion/bypass_security/linux/iptables.yara
@@ -58,4 +58,3 @@ rule iptables_delete: medium {
   condition:
     any of them
 }
-

--- a/rules/evasion/file/location/dev-mqueue.yara
+++ b/rules/evasion/file/location/dev-mqueue.yara
@@ -8,4 +8,3 @@ rule dev_mqueue: medium {
   condition:
     any of them
 }
-

--- a/rules/evasion/file/location/lib.yara
+++ b/rules/evasion/file/location/lib.yara
@@ -44,4 +44,3 @@ rule multiple_lib_so_high: medium linux {
   condition:
     filesize < 10MB and uint32(0) == 1179403647 and #lib > 1
 }
-

--- a/rules/evasion/file/location/var-tmp.yara
+++ b/rules/evasion/file/location/var-tmp.yara
@@ -21,4 +21,3 @@ rule var_tmp_path_hidden: high {
   condition:
     $ref and none of ($not*)
 }
-

--- a/rules/evasion/file/location/x11-unix.yara
+++ b/rules/evasion/file/location/x11-unix.yara
@@ -30,4 +30,3 @@ rule hidden_x11_unexpected: high {
   condition:
     filesize < 10MB and $x11 and none of ($not*)
 }
-

--- a/rules/evasion/file/prefix/proc.yara
+++ b/rules/evasion/file/prefix/proc.yara
@@ -8,4 +8,3 @@ rule hidden_proc: high linux {
   condition:
     filesize < 10MB and all of them
 }
-

--- a/rules/evasion/mimicry/fake-library.yara
+++ b/rules/evasion/mimicry/fake-library.yara
@@ -34,4 +34,3 @@ rule libc_fake_number_val: high {
   condition:
     $ref and none of ($not*)
 }
-

--- a/rules/exec/dylib/iterate.yara
+++ b/rules/exec/dylib/iterate.yara
@@ -9,4 +9,3 @@ rule dl_iterate_phdr {
   condition:
     any of them
 }
-

--- a/rules/exec/dylib/open.yara
+++ b/rules/exec/dylib/open.yara
@@ -21,4 +21,3 @@ rule ruby_dylib: low ruby {
   condition:
     any of them
 }
-

--- a/rules/exfil/curl_post.yara
+++ b/rules/exfil/curl_post.yara
@@ -11,4 +11,3 @@ rule curl_post: medium {
   condition:
     filesize < 8KB and $curl and $post and any of ($http*)
 }
-

--- a/rules/exfil/stealer/creds.yara
+++ b/rules/exfil/stealer/creds.yara
@@ -96,3 +96,22 @@ rule STRRat_critical: critical {
   condition:
     filesize < 128KB and all of ($p*) and any of ($browser*) and any of ($mail*)
 }
+
+rule RustEthereumSolanaStealer: critical {
+  meta:
+    description = "steals ethereum and solana wallet keys via compromised Crates"
+    filetypes   = "rs"
+
+  strings:
+    $base58          = "base58" nocase
+    $base58_alphabet = "const BASE58_ALPHABET: &[u8] = b\"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\";"
+    $endpoint_sub1   = "mainnet"
+    $endpoint_sub2   = "solana-rpc-pool"
+    $endpoint_domain = "workers.dev"
+    $regex1          = "Regex::new(r#\"\\[(?:\\s*0x[0-9a-fA-F]{1,2}\\s*,?\\s*)+\\]|\\[(?:\\s*\\d{1,3}\\s*,?\\s*)+\\]\"#)?"
+    $regex2          = "Regex::new(r#\"\"[1-9A-HJ-NP-Za-km-z]{32,44}\"\"#)?"
+    $regex3          = "Regex::new(r#\"\"0x[0-9a-fA-F]{64}\"\"#)?"
+
+  condition:
+    filesize < 128KB and any of ($base58*) and all of ($endpoint*) and any of ($regex*)
+}

--- a/rules/exfil/stealer/file.yara
+++ b/rules/exfil/stealer/file.yara
@@ -103,4 +103,3 @@ rule curl_easy_exfil: high {
   condition:
     filesize < 1MB and all of them
 }
-

--- a/rules/exfil/stealer/telegram.yara
+++ b/rules/exfil/stealer/telegram.yara
@@ -34,4 +34,3 @@ rule telegram_content: critical {
   condition:
     filesize < 32KB and all of them
 }
-

--- a/rules/false_positives/fzf.yara
+++ b/rules/false_positives/fzf.yara
@@ -9,4 +9,3 @@ rule fzf: override {
   condition:
     filesize < 6MB and any of them
 }
-

--- a/rules/false_positives/kandji.yara
+++ b/rules/false_positives/kandji.yara
@@ -9,4 +9,3 @@ rule kandji: override {
   condition:
     any of them
 }
-

--- a/rules/false_positives/osqueryd.yara
+++ b/rules/false_positives/osqueryd.yara
@@ -10,4 +10,3 @@ rule osqueryd: override {
   condition:
     filesize < 100MB and any of them
 }
-

--- a/rules/fs/event-monitoring.yara
+++ b/rules/fs/event-monitoring.yara
@@ -10,4 +10,3 @@ rule syscall_fanotify_init: linux {
   condition:
     any of them
 }
-

--- a/rules/fs/file/file-truncate.yara
+++ b/rules/fs/file/file-truncate.yara
@@ -22,4 +22,3 @@ rule truncate: harmless {
   condition:
     any of them
 }
-

--- a/rules/fs/path/home-config.yara
+++ b/rules/fs/path/home-config.yara
@@ -8,4 +8,3 @@ rule home_config_path {
   condition:
     any of them
 }
-

--- a/rules/fs/path/home_library.yara
+++ b/rules/fs/path/home_library.yara
@@ -8,4 +8,3 @@ rule home_lib_path {
   condition:
     any of them
 }
-

--- a/rules/fs/proc/pid-statistics.yara
+++ b/rules/fs/proc/pid-statistics.yara
@@ -9,4 +9,3 @@ rule proc_pid_stat_val {
   condition:
     any of them
 }
-

--- a/rules/hw/cpu.yara
+++ b/rules/hw/cpu.yara
@@ -19,4 +19,3 @@ rule CpuInfoAndModel: macos medium {
   condition:
     any of them
 }
-

--- a/rules/impact/remote_access/base64_exec.yara
+++ b/rules/impact/remote_access/base64_exec.yara
@@ -12,4 +12,3 @@ rule hex_convert_base64_ascii: high {
   condition:
     filesize < 32KB and any of ($lang*) and any of ($b*) and any of ($exec*)
 }
-

--- a/rules/impact/remote_access/dl_iterate.yara
+++ b/rules/impact/remote_access/dl_iterate.yara
@@ -12,4 +12,3 @@ rule dl_iterate_cpu_pthreads: high linux {
   condition:
     filesize < 1200KB and uint32(0) == 1179403647 and all of them
 }
-

--- a/rules/impact/remote_access/ssh.yara
+++ b/rules/impact/remote_access/ssh.yara
@@ -24,4 +24,3 @@ rule sshd_backdoor_private_key: critical {
   condition:
     filesize < 5MB and all of them
 }
-

--- a/rules/impact/ui/x11-auth.yara
+++ b/rules/impact/ui/x11-auth.yara
@@ -10,4 +10,3 @@ rule x11_refs: medium {
   condition:
     any of them
 }
-

--- a/rules/impact/ui/xsession.yara
+++ b/rules/impact/ui/xsession.yara
@@ -8,4 +8,3 @@ rule xsession: medium {
   condition:
     any of them
 }
-

--- a/rules/lateral/ssh/worm.yara
+++ b/rules/lateral/ssh/worm.yara
@@ -46,4 +46,3 @@ rule ssh_worm_router: high {
   condition:
     filesize < 1MB and all of ($s*) and any of ($h*) and 2 of ($p*)
 }
-

--- a/rules/malware/family/gelsemium.yara
+++ b/rules/malware/family/gelsemium.yara
@@ -24,4 +24,3 @@ rule wolfsbane_rc4_key: critical linux {
   condition:
     filesize < 10MB and all of them
 }
-

--- a/rules/malware/family/platypus.yara
+++ b/rules/malware/family/platypus.yara
@@ -11,4 +11,3 @@ rule go_platypus: critical {
   condition:
     filesize < 17MB and 3 of them
 }
-

--- a/rules/malware/family/tinyshell.yara
+++ b/rules/malware/family/tinyshell.yara
@@ -22,4 +22,3 @@ rule c_tinyshell: critical {
   condition:
     filesize < 1MB and all of them
 }
-

--- a/rules/malware/family/yakuza.yara
+++ b/rules/malware/family/yakuza.yara
@@ -9,4 +9,3 @@ rule yakuza: critical linux {
   condition:
     uint32(0) == 1179403647 and filesize > 100KB and filesize < 250KB and all of them
 }
-

--- a/rules/malware/ref.yara
+++ b/rules/malware/ref.yara
@@ -19,4 +19,3 @@ rule inject_malware: high {
   condition:
     any of them
 }
-

--- a/rules/net/ssl/socket.yara
+++ b/rules/net/ssl/socket.yara
@@ -9,4 +9,3 @@ rule py_ssl_socket: medium {
   condition:
     all of them
 }
-

--- a/rules/os/fd/sendfile.yara
+++ b/rules/os/fd/sendfile.yara
@@ -11,4 +11,3 @@ rule sendfile {
   condition:
     any of them
 }
-

--- a/rules/os/fd/write.yara
+++ b/rules/os/fd/write.yara
@@ -39,4 +39,3 @@ rule py_fd_write {
   condition:
     any of them
 }
-

--- a/rules/os/kernel/kcore.yara
+++ b/rules/os/kernel/kcore.yara
@@ -9,4 +9,3 @@ rule kcore: unusual {
   condition:
     any of them
 }
-

--- a/rules/os/kernel/key-management.yara
+++ b/rules/os/kernel/key-management.yara
@@ -9,4 +9,3 @@ rule syscall_keyctl {
   condition:
     any of them
 }
-

--- a/rules/os/kernel/sysctl.yara
+++ b/rules/os/kernel/sysctl.yara
@@ -9,4 +9,3 @@ rule sysctl: harmless {
   condition:
     any of them
 }
-

--- a/rules/os/time/tzinfo.yara
+++ b/rules/os/time/tzinfo.yara
@@ -10,4 +10,3 @@ rule tzinfo {
   condition:
     any of them
 }
-

--- a/rules/privesc/setuid.yara
+++ b/rules/privesc/setuid.yara
@@ -85,4 +85,3 @@ rule ruby_setuid_0: high {
   condition:
     any of them
 }
-

--- a/rules/process/group/create.yara
+++ b/rules/process/group/create.yara
@@ -11,4 +11,3 @@ rule syscalls: harmless {
   condition:
     any of them
 }
-

--- a/rules/process/group/set.yara
+++ b/rules/process/group/set.yara
@@ -10,4 +10,3 @@ rule setpgid: harmless {
   condition:
     any of them
 }
-

--- a/rules/process/terminate/arbitrary.yara
+++ b/rules/process/terminate/arbitrary.yara
@@ -19,4 +19,3 @@ rule kill_9_d: high {
   condition:
     any of them
 }
-

--- a/rules/process/terminate/taskkill.yara
+++ b/rules/process/terminate/taskkill.yara
@@ -21,4 +21,3 @@ rule taskkill_force: high windows {
   condition:
     any of them
 }
-

--- a/rules/process/terminate/terminate.yara
+++ b/rules/process/terminate/terminate.yara
@@ -9,4 +9,3 @@ rule TerminateProcess: medium {
   condition:
     any of them
 }
-

--- a/rules/process/unshare.yara
+++ b/rules/process/unshare.yara
@@ -11,4 +11,3 @@ rule syscall_unshare {
   condition:
     any of them
 }
-


### PR DESCRIPTION
This PR adds a rule for the recent Crates.io compromises. It's a bit contrived for the specific sample (i.e., it likely won't apply in a generic sense).

Also, yara-x now formats rules in a slightly different way so I handled that as part of compiling and formatting the new rule.