### PR TITLE
Tweak the release and third-party trust policies

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -7,6 +7,10 @@ spec:
         identities:
           - issuer: https://accounts.google.com
           - issuer: https://github.com/login/oauth
+          - issuer: https://token.actions.githubusercontent.com
+            subject: chainguard-dev/malcontent/.github/workflows/release.yaml@refs/heads/main
+          - issuer: https://token.actions.githubusercontent.com
+            subject: chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg

--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,7 +1,7 @@
 issuer: https://token.actions.githubusercontent.com
 subject: repo:chainguard-dev/malcontent:ref:refs/heads/main
 claim_pattern:
-  job_workflow_ref: chainguard-dev/malcontent/.github/workflows/(version|release).yaml@.*
+  workflow_ref: chainguard-dev/malcontent/.github/workflows/(version|release).yaml@refs/heads/main
 
 permissions:
   contents: write

--- a/.github/chainguard/third-party.sts.yaml
+++ b/.github/chainguard/third-party.sts.yaml
@@ -1,7 +1,7 @@
 issuer: https://token.actions.githubusercontent.com
 subject: repo:chainguard-dev/malcontent:ref:refs/heads/main
 claim_pattern:
-  job_workflow_ref: chainguard-dev/malcontent/.github/workflows/third-party.yaml@.*
+  workflow_ref: chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
 
 permissions:
   contents: write


### PR DESCRIPTION
I've been meaning to update these for a while.

We use the Workflows in `main` and this should hopefully resolve this error:
```
	* none of the expected identities matched what was in the certificate, got subjects [https://github.com/chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main] with issuer https://token.actions.githubusercontent.com

```