### PR TITLE
Use Workflow URIs for source.yaml

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -8,9 +8,9 @@ spec:
           - issuer: https://accounts.google.com
           - issuer: https://github.com/login/oauth
           - issuer: https://token.actions.githubusercontent.com
-            subject: chainguard-dev/malcontent/.github/workflows/release.yaml@refs/heads/main
+            subject: https://github.com/chainguard-dev/malcontent/.github/workflows/release.yaml@refs/heads/main
           - issuer: https://token.actions.githubusercontent.com
-            subject: chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
+            subject: https://github.com/chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
These need to be the full Workflow URIs as opposed to what we use for the `subject` in the trust policy.