### PR TITLE
Add Version Workflow to source.yaml as well

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -11,6 +11,8 @@ spec:
             subject: https://github.com/chainguard-dev/malcontent/.github/workflows/release.yaml@refs/heads/main
           - issuer: https://token.actions.githubusercontent.com
             subject: https://github.com/chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-dev/malcontent/.github/workflows/version.yaml@refs/heads/main
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
One more PR -- the version Workflow shares the same trust policy as the release Workflow but they need separate subjects in `source.yaml`.