### PR TITLE
chore(harden-runner): allow more gitsign endpoints

### DIFF
--- a/.github/workflows/update-yara-x.yaml
+++ b/.github/workflows/update-yara-x.yaml
@@ -96,14 +96,17 @@ jobs:
             *.githubapp.com:443
             api.github.com:443
             dl.google.com:443
+            fulcio.sigstore.dev:443
             github.com:443
             go.dev:443
             objects.githubusercontent.com:443
             octo-sts.dev:443
             proxy.golang.org:443
+            rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
We need these endpoints as well.