### PR TITLE
chore(action-lint): address findings

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -8,6 +8,8 @@ spec:
           - issuer: https://accounts.google.com
           - issuer: https://github.com/login/oauth
           - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-dev/malcontent/.github/workflows/digestabot.yaml@refs/heads/main
+          - issuer: https://token.actions.githubusercontent.com
             subject: https://github.com/chainguard-dev/malcontent/.github/workflows/release.yaml@refs/heads/main
           - issuer: https://token.actions.githubusercontent.com
             subject: https://github.com/chainguard-dev/malcontent/.github/workflows/third-party.yaml@refs/heads/main
@@ -18,3 +20,6 @@ spec:
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg
+  # Allow GitHub verified ssh, gpg, and smime signatures
+  github:
+    verified: true

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Custom GitHub-hosted runner labels used by Chainguard
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-16-core
+    - ubuntu-latest-arm-16-core

--- a/.github/chainguard/digestabot.sts.yaml
+++ b/.github/chainguard/digestabot.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/malcontent:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: chainguard-dev/malcontent/.github/workflows/digestabot.yaml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,6 +46,8 @@ jobs:
             sum.golang.org:443
             uploads.github.com:443
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Cache yara-x-capi installation
         id: yara-x-capi
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -56,6 +58,7 @@ jobs:
         if: steps.yara-x-capi.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
           repository: virusTotal/yara-x
@@ -135,6 +138,8 @@ jobs:
             uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,54 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Image digest update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+permissions: {}
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+    if: github.repository == 'chainguard-dev/malcontent'
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            api.github.com:443
+            cgr.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            octo-sts.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      - uses: chainguard-dev/actions/setup-gitsign@de68b87302e6266db5fb5220246f8aa46fe94b67
+
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: digestabot
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] - credentials needed for digestabot to push and create PRs
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - uses: chainguard-dev/digestabot@afe360aa3b0c29d88844138e8fa0349384398967 # v1.3.1
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          include-files: ".github/workflows/*.yaml"

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -108,7 +108,7 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.discover.outputs.targets) }}
     container:
-      image: cgr.dev/chainguard/wolfi-base:latest # zizmor: ignore[unpinned-images]
+      image: cgr.dev/chainguard/wolfi-base:latest@sha256:9a74366aa10eff2bf14dab0948123bd2c51703e1c553a73740ef687f723aecf4
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: cgr.dev/chainguard/wolfi-base:latest # zizmor: ignore[unpinned-images]
+      image: cgr.dev/chainguard/wolfi-base:latest@sha256:9a74366aa10eff2bf14dab0948123bd2c51703e1c553a73740ef687f723aecf4
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: cgr.dev/chainguard/wolfi-base:latest # zizmor: ignore[unpinned-images]
+      image: cgr.dev/chainguard/wolfi-base:latest@sha256:9a74366aa10eff2bf14dab0948123bd2c51703e1c553a73740ef687f723aecf4
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,6 @@ jobs:
             github.com:443
             octo-sts.dev:443
             release-assets.githubusercontent.com:443
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: chainguard-dev/actions/setup-gitsign@de68b87302e6266db5fb5220246f8aa46fe94b67
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
@@ -38,6 +36,11 @@ jobs:
         with:
           scope: chainguard-dev/malcontent
           identity: release
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] - credentials needed for gh release create
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Get Version
         id: get-version
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -83,18 +83,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install yara-x
+      - name: Run make yara-x-fmt
         run: |
-          wget https://github.com/VirusTotal/yara-x/releases/download/v${{ env.YARA_X_RELEASE }}/yara-x-v${{ env.YARA_X_RELEASE }}-aarch64-unknown-linux-gnu.gz -O yara-x.gz
-          gunzip yara-x.gz && tar -xvf yara-x && chmod +x yr && mv yr /usr/local/bin/ && rm yara-x
-      - name: Verify yr installation
-        run: |
-          yr --version
-      - name: Run yr fmt
-        run: |
-          find rules -type f -name "*.yara" | xargs -n 1 -I {} yr fmt {}
+          make yara-x-fmt
           if [[ -n $(git status -s) ]]; then
-            echo "Rule files updated; please run yr fmt locally and commit the changes"
+            echo "Rule files updated; please run 'make yara-x-fmt' locally and commit the changes"
             exit 1
           fi
 
@@ -178,7 +171,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: cgr.dev/chainguard/wolfi-base:latest
+      image: cgr.dev/chainguard/wolfi-base:latest@sha256:9a74366aa10eff2bf14dab0948123bd2c51703e1c553a73740ef687f723aecf4
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository == 'chainguard-dev/malcontent' }}
     runs-on: ubuntu-latest-arm-16-core
     container:
-      image: cgr.dev/chainguard/wolfi-base:latest
+      image: cgr.dev/chainguard/wolfi-base:latest@sha256:9a74366aa10eff2bf14dab0948123bd2c51703e1c553a73740ef687f723aecf4
       options: >-
         --cap-add DAC_OVERRIDE
         --cap-add SETGID
@@ -41,7 +41,17 @@ jobs:
         run: |
           apk update
           apk add bash curl findutils gh git gnutar ${{ env.GO_RELEASE }} nodejs perl upx xz yara-x~${{ env.YARA_X_RELEASE }}
+      - uses: chainguard-dev/actions/setup-gitsign@de68b87302e6266db5fb5220246f8aa46fe94b67
+      - name: Set up Octo-STS
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: chainguard-dev/malcontent
+          identity: third-party
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] - credentials needed for git push and gh pr create
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Trust repository
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
@@ -72,14 +82,6 @@ jobs:
 
       - name: Prepare samples
         run: make samples
-
-      - uses: chainguard-dev/actions/setup-gitsign@de68b87302e6266db5fb5220246f8aa46fe94b67
-      - name: Set up Octo-STS
-        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
-        id: octo-sts
-        with:
-          scope: chainguard-dev/malcontent
-          identity: third-party
 
       - name: Run make update-third-party
         run: |

--- a/.github/workflows/update-yara-x.yaml
+++ b/.github/workflows/update-yara-x.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for new yara-x version
         id: check
@@ -119,6 +121,7 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] - credentials needed for git push and gh pr create
         with:
           token: ${{ steps.octo-sts.outputs.token }}
 

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -39,7 +39,6 @@ jobs:
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             tuf-repo-cdn.sigstore.dev:443
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: chainguard-dev/actions/setup-gitsign@de68b87302e6266db5fb5220246f8aa46fe94b67
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
@@ -47,6 +46,10 @@ jobs:
         with:
           scope: chainguard-dev/malcontent
           identity: release
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] - credentials needed for git push and gh pr create
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Update Version
         id: update
         env:
@@ -63,13 +66,13 @@ jobs:
 
           case "${UPDATE_TYPE}" in
             major)
-              VERSION=$(printf "v%d.0.0" $((${VERSION_PARTS[0]}+1)))
+              VERSION=$(printf "v%d.0.0" $((VERSION_PARTS[0]+1)))
               ;;
             minor)
-              VERSION=$(printf "v%s.%d.0" ${VERSION_PARTS[0]} $((${VERSION_PARTS[1]}+1)))
+              VERSION=$(printf "v%s.%d.0" "${VERSION_PARTS[0]}" $((VERSION_PARTS[1]+1)))
               ;;
             patch)
-              VERSION=$(printf "v%s.%s.%d" ${VERSION_PARTS[0]} ${VERSION_PARTS[1]} $((${VERSION_PARTS[2]}+1)))
+              VERSION=$(printf "v%s.%s.%d" "${VERSION_PARTS[0]}" "${VERSION_PARTS[1]}" $((VERSION_PARTS[2]+1)))
               ;;
             *)
               echo "Error: Invalid update type"


### PR DESCRIPTION
This PR addresses all of the active `action-lint` + Zizmor findings and also adds a Digestabot Workflow to keep our pinned `wolfi-base` digests up to date which Dependabot cannot do.