### PR TITLE
fix(ci): resolve template injection and ref-version-mismatch findings

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -80,16 +80,18 @@ jobs:
           restore-keys: rust-cargo-
       - name: Build yara-x-capi
         if: steps.yara-x-capi.outputs.cache-hit != 'true'
+        env:
+          WORKSPACE: ${{ github.workspace }}
         run: |
           command -v cargo-cinstall || cargo install cargo-c --locked
-          cd ${{ github.workspace }}/yara-x
+          cd "${WORKSPACE}/yara-x"
           RUSTFLAGS="-C target-feature=+crt-static" cargo cinstall -p yara-x-capi --features=native-code-serialization \
             --profile release-lto \
-            --pkgconfigdir=${{ github.workspace }}/yara-x-install \
-            --includedir=${{ github.workspace }}/yara-x-install \
-            --libdir=${{ github.workspace }}/yara-x-install \
+            --pkgconfigdir="${WORKSPACE}/yara-x-install" \
+            --includedir="${WORKSPACE}/yara-x-install" \
+            --libdir="${WORKSPACE}/yara-x-install" \
             --crt-static --library-type="staticlib"
-          rm -rf ${{ github.workspace }}/yara-x
+          rm -rf "${WORKSPACE}/yara-x"
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -66,7 +66,7 @@ jobs:
           ref: refs/tags/v${{ env.YARA_X_RELEASE }}
       - name: Install Rust for yara-x-capi
         if: steps.yara-x-capi.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - name: Cache Rust dependencies

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -36,7 +36,7 @@ jobs:
             release-assets.githubusercontent.com:443
             tuf-repo-cdn.sigstore.dev:443
 
-      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
+      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d # main
 
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add curl findutils git gnutar ${{ env.GO_RELEASE }} nodejs upx xz yara-x~${{ env.YARA_X_RELEASE }}
+          apk add curl findutils git gnutar "${GO_RELEASE}" nodejs upx xz "yara-x~${YARA_X_RELEASE}"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -170,6 +170,8 @@ jobs:
       # -parallel=1 is used for now due to this: https://github.com/golang/go/issues/56238
       - name: Run fuzzer - ${{ matrix.target.test }}
         env:
+          FUZZ_TARGET: ${{ matrix.target.test }}
+          FUZZ_PACKAGE: ${{ matrix.target.package }}
           FUZZ_TIME: ${{ inputs.fuzz_time || '30s' }}
         run: |
-          go test -parallel=1 -timeout 0 -fuzz="^${{ matrix.target.test }}$" -fuzztime="${FUZZ_TIME}" "${{ matrix.target.package }}"
+          go test -parallel=1 -timeout 0 -fuzz="^${FUZZ_TARGET}$" -fuzztime="${FUZZ_TIME}" "${FUZZ_PACKAGE}"

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add curl findutils git gnutar ${{ env.GO_RELEASE }} nodejs upx xz yara-x~${{ env.YARA_X_RELEASE }}
+          apk add curl findutils git gnutar "${GO_RELEASE}" nodejs upx xz "yara-x~${YARA_X_RELEASE}"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add curl findutils git gnutar ${{ env.GO_RELEASE }} nodejs upx xz yara-x~${{ env.YARA_X_RELEASE }}
+          apk add curl findutils git gnutar "${GO_RELEASE}" nodejs upx xz "yara-x~${YARA_X_RELEASE}"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             github.com:443
             octo-sts.dev:443
             release-assets.githubusercontent.com:443
-      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
+      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d # main
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add curl findutils git ${{ env.GO_RELEASE }} nodejs yara-x~${{ env.YARA_X_RELEASE }}
+          apk add curl findutils git "${GO_RELEASE}" nodejs "yara-x~${YARA_X_RELEASE}"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           apk update
           apk add bash curl findutils gh git gnutar "${GO_RELEASE}" nodejs perl upx xz "yara-x~${YARA_X_RELEASE}"
-      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
+      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d # main
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts

--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add bash curl findutils gh git gnutar ${{ env.GO_RELEASE }} nodejs perl upx xz yara-x~${{ env.YARA_X_RELEASE }}
+          apk add bash curl findutils gh git gnutar "${GO_RELEASE}" nodejs perl upx xz "yara-x~${YARA_X_RELEASE}"
       - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1

--- a/.github/workflows/update-yara-x.yaml
+++ b/.github/workflows/update-yara-x.yaml
@@ -112,7 +112,7 @@ jobs:
             sum.golang.org:443
             tuf-repo-cdn.sigstore.dev:443
 
-      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
+      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d # main
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts

--- a/.github/workflows/update-yara-x.yaml
+++ b/.github/workflows/update-yara-x.yaml
@@ -46,6 +46,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           CURRENT=$(grep '^YARA_X_VERSION' Makefile | head -1 | sed 's/.*= *//')
           echo "Current version: ${CURRENT}"
@@ -68,7 +69,7 @@ jobs:
 
           # Skip if there is already an open PR for this version
           VERSION="${LATEST#v}"
-          EXISTING=$(gh pr list --repo "${{ github.repository }}" --head "bump-yara-x-${VERSION}" --state open --json number --jq 'length')
+          EXISTING=$(gh pr list --repo "${REPOSITORY}" --head "bump-yara-x-${VERSION}" --state open --json number --jq 'length')
           if [[ "${EXISTING}" -gt 0 ]]; then
             echo "Open PR already exists for yara-x ${VERSION}"
             echo "update_available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -39,7 +39,7 @@ jobs:
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             tuf-repo-cdn.sigstore.dev:443
-      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d
+      - uses: chainguard-dev/actions/setup-gitsign@4a81273c8653122cf4e48cc248f9073b660c5e6d # main
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  # Pedantic-only; low security value but noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

**Ticket**: PSEC-923
**Date**: 2026-05-03
**Patches**: 3

---

## Summary

This patch series addresses GitHub Actions security findings in `chainguard-dev/malcontent`
as part of the PSEC-923 systematic hardening campaign across Chainguard public repositories.

### Patch 0001 — fix(ci): resolve template injection findings

Fixes 18 `template-injection` findings (zizmor pedantic persona) across 6 workflow files
by moving `${{ context }}` template expressions out of `run:` blocks and into `env:`
variables or using the shell variables that the workflow-level `env:` block already exports.

**Files changed**:
- `.github/workflows/codeql.yaml` — `${{ github.workspace }}` in "Build yara-x-capi" step
  moved to `env: WORKSPACE:` and referenced as `"${WORKSPACE}"` in the run block.
- `.github/workflows/fuzz.yaml` — `${{ env.GO_RELEASE }}` and `${{ env.YARA_X_RELEASE }}`
  replaced with shell variable references `"${GO_RELEASE}"` and `"yara-x~${YARA_X_RELEASE}"`;
  `${{ matrix.target.test }}` and `${{ matrix.target.package }}` moved to `env: FUZZ_TARGET:`
  and `env: FUZZ_PACKAGE:` in the "Run fuzzer" step.
- `.github/workflows/go-tests.yaml` — same `env.GO_RELEASE`/`env.YARA_X_RELEASE` fix in
  both the `test` and `integration` job "Install dependencies" steps.
- `.github/workflows/style.yaml` — same fix in the `golangci-lint` job "Install dependencies".
- `.github/workflows/third-party.yaml` — same fix in "Install dependencies".
- `.github/workflows/update-yara-x.yaml` — `${{ github.repository }}` moved to
  `env: REPOSITORY:` in the "Check for new yara-x version" step.

**Note on `env.*` fixes**: The `${{ env.GO_RELEASE }}` and `${{ env.YARA_X_RELEASE }}`
expressions appear in container-job `apk add` lines. Since these are workflow-level `env:`
variables, they are already exported to the shell environment as `$GO_RELEASE` and
`$YARA_X_RELEASE`. The fix simply removes the template expression and uses the shell
variables directly — no functional change.

### Patch 0002 — fix(ci): add pedantic persona and suppress noisy zizmor rules

- Creates `.github/zizmor.yml` with:
  - `dependabot-cooldown` configured to 3 days
  - `anonymous-definition`, `undocumented-permissions`, `concurrency-limits` disabled
    (pedantic-only rules with no security impact)
- Updates `.github/workflows/zizmor.yaml`:
  - Adds `persona: pedantic` to the `zizmorcore/zizmor-action` step so CI catches all
    `run:` block template expansions going forward
  - Extends `paths:` triggers to include `.github/zizmor.yml` and `.github/dependabot.yml`
    so changes to those files also trigger the workflow check

### Patch 0003 — fix(ci): add missing version comments to SHA-pinned action refs

Resolves 6 `ref-version-mismatch` zizmor findings by annotating SHA-pinned action refs
with their corresponding version:

- `chainguard-dev/actions/setup-gitsign@4a81273c` (5 occurrences across `digestabot.yaml`,
  `release.yaml`, `update-yara-x.yaml`, `version.yaml`, `third-party.yaml`): add `# main`.
  This action tracks the rolling `main` branch; no semver tags are published.
- `dtolnay/rust-toolchain@e97e2d8` in `codeql.yaml`: add `# v1`.

Two additional `ref-version-mismatch` findings (`chainguard-dev/actions/gofmt` and
`chainguard-dev/actions/goimports`) already had `# main` comments and needed no change.

Note: `step-security/harden-runner` was at v2.19.0 when this series was drafted;
dependabot bumped it to v2.19.1 upstream before this PR landed, so that update
is not included.

---

## Findings not addressed in this series

- **1 superfluous-actions**: `dtolnay/rust-toolchain` in `codeql.yaml` — zizmor suggests
  replacing with native `rustup`, but the action provides additional conveniences and the
  security improvement is marginal. Left for repo owners to decide.
- **12 `concurrency-limits`**, **11 `anonymous-definition`**, **8 `undocumented-permissions`**,
  **2 `dependabot-cooldown`** — suppressed via `.github/zizmor.yml` (pedantic-only, no
  security impact).

---

## Testing notes

1. Apply patches with `git am 0001-*.patch 0002-*.patch 0003-*.patch`
2. Verify the template injection fixes do not break CI by checking that:
   - `apk add "${GO_RELEASE}"` and `"yara-x~${YARA_X_RELEASE}"` work correctly in the
     container jobs (the workflow-level env vars are passed into the container environment)
   - The fuzz job's `go test -fuzz="^${FUZZ_TARGET}$"` pattern matches correctly
   - The codeql job's `"${WORKSPACE}/yara-x"` path resolves correctly
3. Run `zizmor --persona=pedantic .github/` against the patched repo to verify zero
   remaining `template-injection` and `ref-version-mismatch` findings
4. Confirm zizmor CI workflow triggers on a PR that modifies `.github/zizmor.yml`

---

Refs: PSEC-923