### PR TITLE
chore(samples): bump commit and add new npm test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SAMPLES_REPO ?= chainguard-sandbox/malcontent-samples
-SAMPLES_COMMIT ?= f948cfd0f9d2a35a2452fe43ea4d094979652103
+SAMPLES_COMMIT ?= fca96935d01d3b0a7a2765626279c676bd9d495f
 
 # BEGIN: lint-install ../malcontent
 # http://github.com/tinkerbell/lint-install

--- a/tests/npm/2025.shai-hulud/package.json.simple
+++ b/tests/npm/2025.shai-hulud/package.json.simple
@@ -1,0 +1,7 @@
+# npm/2025.shai-hulud/package.json: high
+exfil: medium
+exfil/npm: high
+fs/file/read: low
+net/http/post: medium
+net/url/embedded: low
+os/env/get: low


### PR DESCRIPTION
Relates to: #1501

This PR bumps the `malcontent-samples` commit and adds a testdata file to capture the behaviors from the new sample.