### PR TITLE
remove extraneous } from third-party.yaml

### DIFF
--- a/.github/workflows/third-party.yaml
+++ b/.github/workflows/third-party.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add bash curl findutils gcc gh git gnutar "${GO_RELEASE}"} make nodejs perl pkgconf upx xz "yara-x~${YARA_X_RELEASE}"
+          apk add bash curl findutils gcc gh git gnutar "${GO_RELEASE}" make nodejs perl pkgconf upx xz "yara-x~${YARA_X_RELEASE}"
       - uses: chainguard-dev/actions/setup-gitsign@c69a264ec2a5934c3186c618f368fc1c86f16cff # main
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1


### PR DESCRIPTION
I missed this when reconciling the merge conflicts in the original PR.