### PR TITLE
chore(yara_x_bin): update release archive extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,13 @@ else ifeq ($(LINT_OS),Linux)
 	endif
 endif
 YARA_X_BIN := $(LINT_ROOT)/out/linters/yr-$(YARA_X_VERSION)-$(LINT_ARCH)
+YARA_X_RELEASE_EXT := .tar.gz
 $(YARA_X_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters
 	rm -rf $(LINT_ROOT)/out/linters/yr
-	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER)$(LINT_PLATFORM_SUFFIX).gz -o yara-x.gz
-	echo "$(YARA_X_SHA) *yara-x.gz" | shasum -a 256 --check
-	tar -xzvf yara-x.gz && mv yr $(LINT_ROOT)/out/linters && rm yara-x.gz
+	curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/$(YARA_X_VERSION)/yara-x-$(YARA_X_VERSION)-$(LINT_ARCH)-$(LINT_PLATFORM)-$(LINT_OS_LOWER)$(LINT_PLATFORM_SUFFIX)$(YARA_X_RELEASE_EXT) -o yara-x$(YARA_X_RELEASE_EXT)
+	echo "$(YARA_X_SHA) *yara-x$(YARA_X_RELEASE_EXT)" | shasum -a 256 --check
+	tar -xzvf yara-x$(YARA_X_RELEASE_EXT) && mv yr $(LINT_ROOT)/out/linters && rm yara-x$(YARA_X_RELEASE_EXT)
 	mv $(LINT_ROOT)/out/linters/yr $@
 
 LINTERS += golangci-lint-lint


### PR DESCRIPTION
This PR addresses all of the recent CI failures:
```
curl -sSfL https://github.com/VirusTotal/yara-x/releases/download/v1.17.0/yara-x-v1.17.0-aarch64-unknown-linux-gnu.gz -o yara-x.gz
curl: (22) The requested URL returned error: 404
```

The release artifacts are now stored as `.tar.gz` rather than `.gz`.